### PR TITLE
fixed examples/side_panel

### DIFF
--- a/examples/side_panel.py
+++ b/examples/side_panel.py
@@ -153,7 +153,7 @@ class SidePanel(Window):
         self.cpu_circular_progress_bar.percentage = psutil.cpu_percent()
         self.memory_circular_progress_bar.percentage = psutil.virtual_memory().percent
         self.battery_circular_progress_bar.percentage = (
-            psutil.sensors_battery().percentage
+            psutil.sensors_battery().percent
             if psutil.sensors_battery() is not None
             else 82
         )


### PR DESCRIPTION
`line 170, in <module>
    SidePanel()
  File "/home/deepak/temp/fabric-test/side_panel.py", line 49, in __init__
    self.update_status()
  File "/home/deepak/temp/fabric-test/side_panel.py", line 156, in update_status
    psutil.sensors_battery().percentage
AttributeError: 'sbattery' object has no attribute 'percentage'. Did you mean: 'percent'?`
