### PR TITLE
feat: add bluetooth service and provide example

### DIFF
--- a/examples/bluetooth-widget/bluetooth_widget.css
+++ b/examples/bluetooth-widget/bluetooth_widget.css
@@ -1,0 +1,46 @@
+
+* {
+    all: unset;
+    font-family: "roboto";
+    font-weight: 500;
+    font-size: 14px;
+    color: white;
+}
+
+#main-window {
+    border: solid 2px;
+    border-color: #51A4E7;
+    background-color: rgba(36, 36, 36, 0.8);
+    border-radius: 10px;
+}
+
+#bt-box {
+    margin: 10px;
+    min-width: 350px;
+}
+
+#bt-device-box {
+    margin-top: 2px;
+    margin-bottom: 2px;
+    padding: 10px;
+    background-color: rgba(80, 80, 80, 0.5);
+    border-radius: 10px;
+}
+
+button {
+    border-radius: 5px;
+    background-color: black;
+    padding: 5px;
+    border: solid 2px;
+    border-color: white;
+}
+
+button:hover {
+    background-color: rgb(125, 125, 125);
+
+}
+
+button:active {
+    background-color: #088EAE;
+    border-color: #088EAE;
+}

--- a/examples/bluetooth-widget/bluetooth_widget.py
+++ b/examples/bluetooth-widget/bluetooth_widget.py
@@ -1,0 +1,118 @@
+import fabric
+from loguru import logger
+from fabric.widgets.box import Box
+from fabric.widgets.label import Label
+from fabric.widgets.image import Image
+from fabric.widgets.button import Button
+from fabric.widgets.wayland import Window
+from fabric.widgets.centerbox import CenterBox
+from fabric.widgets.scrolled_window import ScrolledWindow
+from fabric.bluetooth.service import BluetoothClient, BluetoothDevice
+from fabric.utils import set_stylesheet_from_file, get_relative_path
+
+
+class BtDeviceBox(CenterBox):
+    def __init__(self, device: BluetoothDevice, **kwargs):
+        super().__init__(spacing=2, name="bt-device-box", **kwargs)
+        self.device = device
+        self.device.connect("closed", lambda _: self.destroy())
+
+        self.connect_button = Button()
+        self.connect_button.connect(
+            "clicked", lambda _: self.device.set_connection(not self.device.connected)
+        )
+        self.device.connect("notify::connecting", self.on_device_connecting)
+        self.device.connect("notify::connected", self.on_device_connect)
+
+        self.add_left(Image(icon_name=device.icon, icon_size=6))  # type: ignore
+        self.add_left(Label(label=device.name))  # type: ignore
+        self.add_right(self.connect_button)
+
+    def on_device_connecting(self, *args):
+        self.connect_button.set_label(
+            "connecting..."
+        ) if self.device.connecting else self.connect_button.set_label(
+            "failed to connect"
+        )
+
+    def on_device_connect(self, *args):
+        self.connect_button.set_label(
+            "connected"
+        ) if self.device.connected else self.connect_button.set_label("disconnected")
+
+
+class BtConnectionsList(Box):
+    def __init__(self, **kwargs):
+        super().__init__(
+            orientation="vertical",
+            spacing=5,
+            name="bt-box",
+            **kwargs,
+        )
+
+        self.client = BluetoothClient()
+        self.client.connect("device-added", self.new_device)
+        self.scan_button = Button()
+        self.scan_button.connect("clicked", lambda _: self.client.toggle_scan())
+        self.client.connect(
+            "notify::scanning",
+            lambda *args: self.scan_button.set_label("stop")
+            if self.client.scanning
+            else self.scan_button.set_label("scan"),
+        )
+        self.toggle_button = Button()
+        self.toggle_button.connect("clicked", lambda _: self.client.toggle_power())
+        self.client.connect(
+            "notify::enabled",
+            lambda *args: self.toggle_button.set_label("bluetooth on")
+            if self.client.enabled
+            else self.toggle_button.set_label("bluetooth off"),
+        )
+
+        self.paired_box = Box(orientation="vertical")
+        self.available_box = Box(orientation="vertical")
+
+        self.add(
+            CenterBox(left_widgets=self.scan_button, right_widgets=self.toggle_button)
+        )
+        self.add(Label("Paired Devices"))
+        self.add(self.paired_box)
+        self.add(Label("Available Devices"))
+        self.add(
+            ScrolledWindow(
+                min_content_height=400,
+                children=self.available_box,
+            )
+        )
+
+    def new_device(self, client: BluetoothClient, address):
+        device: BluetoothDevice = client.get_device_from_addr(address)
+        if device.paired:
+            self.paired_box.add(BtDeviceBox(device))
+        else:
+            self.available_box.add(BtDeviceBox(device))
+
+
+class BluetoothWidget(Window):
+    def __init__(self, **kwargs):
+        super().__init__(
+            layer="top",
+            anchor="top right",
+            all_visible=True,
+            exclusive=True,
+            name="main-window",
+        )
+        self.btbox = BtConnectionsList()
+        self.add(self.btbox)
+        self.show_all()
+
+
+def apply_style(*args):
+    logger.info("[Bluetooth Widget] CSS applied")
+    return set_stylesheet_from_file(get_relative_path("bluetooth_widget.css"))
+
+
+if __name__ == "__main__":
+    bt = BluetoothWidget()
+    apply_style()
+    fabric.start()

--- a/fabric/bluetooth/service.py
+++ b/fabric/bluetooth/service.py
@@ -1,0 +1,279 @@
+import gi
+from typing import Callable, Dict, List
+from loguru import logger
+from fabric.service import Service, Signal, SignalContainer, Property
+from fabric.utils import bulk_connect
+from gi.repository import Gio, GLib
+
+
+class GnomeBluetoothImportError(ImportError):
+    def __init__(self, *args):
+        super().__init__(
+            "gnome-bluetooth-3 is not installed, please install it first",
+            *args,
+        )
+
+
+try:
+    gi.require_version("GnomeBluetooth", "3.0")
+    from gi.repository import GnomeBluetooth
+except ValueError:
+    raise GnomeBluetoothImportError()
+
+
+class BluetoothDevice(Service):
+    __gsignals__ = SignalContainer(
+        Signal("changed", "run-first", None, ()),  # type: ignore
+        Signal("closed", "run-first", None, ()),  # type: ignore
+    )
+
+    def __init__(
+        self, device: GnomeBluetooth.Device, client: GnomeBluetooth.Client, **kwargs
+    ):
+        self._device: GnomeBluetooth.Device = device
+        self._client: GnomeBluetooth.Client = client
+        self._signal_connectors: dict = {}
+        for sn in [
+            "battery-percentage",
+            "battery-level",
+            "connected",
+            "trusted",
+            "address",
+            "paired",
+            "alias",
+            "icon",
+            "name",
+        ]:
+            self._signal_connectors[sn] = self._device.connect(
+                f"notify::{sn}", lambda *args, sn=sn: self.notifier(sn, args)
+            )
+        super().__init__(**kwargs)
+        # To get the current state of connection
+        GLib.idle_add(lambda: self.notify("connected"))
+
+    @Property(value_type=object, flags="readable")
+    def device(self) -> GnomeBluetooth.Device:
+        return self._device
+
+    @Property(value_type=str, flags="readable")
+    def address(self) -> str:
+        return self._device.props.address
+
+    @Property(value_type=str, flags="readable")
+    def alias(self) -> str:
+        return self._device.props.alias
+
+    @Property(value_type=str, flags="readable")
+    def name(self) -> str:
+        return self._device.props.name
+
+    @Property(value_type=str, flags="readable")
+    def icon(self) -> str:
+        return self._device.props.icon
+
+    @Property(value_type=str, flags="readable")
+    def type(self) -> str:
+        return GnomeBluetooth.type_to_string(self._device.type)  # type: ignore
+
+    @Property(value_type=bool, default_value=False, flags="readable")
+    def paired(self) -> bool:
+        return self._device.props.paired
+
+    @Property(value_type=bool, default_value=False, flags="readable")
+    def trusted(self) -> bool:
+        return self._device.props.trusted
+
+    @Property(value_type=bool, default_value=False, flags="readable")
+    def connected(self) -> bool:
+        return self._device.props.connected
+
+    @Property(value_type=bool, default_value=False, flags="read-write")
+    def connecting(self) -> bool:  # type: ignore
+        return self._connecting
+
+    @connecting.setter
+    def connecting(self, value: bool):
+        self._connecting = value
+        self.notify("connecting")
+        return
+
+    @Property(value_type=int, flags="readable")
+    def battery_level(self) -> int:
+        return self._device.props.battery_level
+
+    @Property(value_type=float, flags="readable")
+    def battery_percentage(self) -> float:
+        return self._device.props.battery_percentage
+
+    def set_connection(self, connect: bool):
+        self.connecting = True
+        self.connect_device(
+            connect, lambda *args: self.set_property("connecting", False)
+        )
+
+    def connect_device(self, connection: bool, callback: Callable):
+        def inner_callback(client: GnomeBluetooth.Client, res: Gio.AsyncResult):
+            try:
+                finish = client.connect_service_finish(res)
+                logger.info(f"[Bluetooth] Connected to device {self.address}")
+                callback(finish)
+            except Exception:
+                logger.warning(f"[Bluetooth] Failed to connect to device {self.address}")
+                callback(False)
+
+        self._client.connect_service(
+            self._device.get_object_path(),
+            connection,
+            None,
+            inner_callback,
+        )
+
+    def close(self):
+        for id in self._signal_connectors.values():
+            try:
+                self._device.disconnect(id)
+            except Exception:
+                pass
+        self.emit("closed")
+
+    def notifier(self, name: str, args=None):
+        self.notify(name)
+        self.emit("changed")
+        return
+
+
+class BluetoothClient(Service):
+    __gsignals__ = SignalContainer(
+        Signal("device-added", "run-first", None, (str,)),
+        Signal("device-removed", "run-first", None, (str,)),
+        Signal("changed", "run-first", None, ()),  # type: ignore
+        Signal("closed", "run-first", None, ()),  # type: ignore
+    )
+
+    def __init__(self, **kwargs):
+        self._client: GnomeBluetooth.Client = GnomeBluetooth.Client.new()  # type: ignore
+        self._devices: Dict[str, GnomeBluetooth.Device] = {}
+        bulk_connect(
+            self._client,
+            {
+                "device-added": self.on_device_added,
+                "device-removed": self.on_device_removed,
+                "notify::default-adapter-state": lambda *args: self.notifier("state"),
+                "notify::default-adapter-powered": lambda *args: self.notifier(
+                    "enabled"
+                ),
+                "notify::default-adapter-setup-mode": lambda *args: self.notifier(
+                    "scanning"
+                ),
+            },
+        )
+        for device in self._get_devices():
+            self.on_device_added(self._client, device)  # type: ignore
+        super().__init__(**kwargs)
+
+    def toggle_power(self):
+        GLib.idle_add(
+            lambda: self._client.set_property(
+                "default_adapter_powered",
+                not self._client.props.default_adapter_powered,
+            )
+        )
+
+    def toggle_scan(self):
+        GLib.idle_add(
+            lambda: self._client.set_property(
+                "default_adapter_setup_mode",
+                not self._client.props.default_adapter_setup_mode,
+            )
+        )
+
+    def _get_devices(self):
+        devices = []
+        device_store: Gio.ListStore = self._client.get_devices()  # type: ignore
+        for i in range(device_store.get_n_items()):
+            device: GnomeBluetooth.Device = device_store.get_item(i)  # type: ignore
+            if device.props.paired or device.props.trusted:
+                devices.append(device)
+        return devices
+
+    def on_device_added(
+        self, client: GnomeBluetooth.Client, device: GnomeBluetooth.Device
+    ):
+        if device.props.address in self._devices.keys():
+            return
+        # This may be a mistake, it fixed an issue with me but might not be the right choice
+        #  We should probably let the user choose what to do with devices with no name
+        if device.props.name is None:
+            return
+        logger.info(f"[Bluetooth] Device added: {device.props.address}")
+        bluetooth_device: BluetoothDevice = BluetoothDevice(device, self._client)
+        bluetooth_device.connect("changed", lambda _: self.emit("changed"))
+        bluetooth_device.connect(
+            "notify::connected", lambda *args: self.notify("connected-devices")
+        )
+        self._devices[device.props.address] = bluetooth_device
+        self.notifier("devices")
+        self.emit("device-added", device.props.address)
+
+    def on_device_removed(self, client: GnomeBluetooth.Client, object_path: str):
+        addr = object_path.split("/")[-1][4:].replace("_", ":")
+        if addr not in self._devices.keys():
+            return
+        logger.info(f"[Bluetooth] Device removed: {addr}")
+        was_connected: bool = self._devices[addr].connected
+        self._devices[addr].close()
+        self._devices.pop(addr)
+        self.notifier("devices")
+        if was_connected:
+            self.notifier("connected-devices")
+        self.emit("device-removed", addr)
+
+    def get_device_from_addr(self, address: str) -> BluetoothDevice:
+        return self._devices[address]
+
+    def notifier(self, name: str, args=None):
+        self.notify(name)
+        self.emit("changed")
+        return
+
+    @Property(value_type=object, flags="readable")
+    def devices(self) -> List:
+        return list(self._devices.values())
+
+    @Property(value_type=object, flags="readable")
+    def connected_devices(self) -> List:
+        ret = []
+        for device in self._devices.values():
+            if device.connected:
+                ret.append(device)
+        return ret
+
+    @Property(value_type=str, flags="readable")
+    def state(self) -> str:
+        return {
+            GnomeBluetooth.AdapterState.ABSENT: "absent",
+            GnomeBluetooth.AdapterState.ON: "on",
+            GnomeBluetooth.AdapterState.TURNING_ON: "turning-on",
+            GnomeBluetooth.AdapterState.TURNING_OFF: "turning-off",
+            GnomeBluetooth.AdapterState.OFF: "off",
+        }.get(self._client.props.default_adapter_state, "unknown")
+
+    @Property(value_type=int, flags="read-write")
+    def scanning(self) -> int:  # type: ignore[no-redef]
+        return self._client.props.default_adapter_setup_mode
+
+    @scanning.setter
+    def scanning(self, value):
+        GLib.idle_add(
+            lambda: self._client.set_property("default_adapter_setup_mode", value)
+        )
+
+    @Property(value_type=bool, default_value=False, flags="read-write")
+    def enabled(self) -> bool:  # type: ignore[no-redef]
+        return True if self.props.state in ["on", "turning-on"] else False
+
+    @enabled.setter
+    def enabled(self, value: bool):
+        GLib.idle_add(
+            lambda: self._client.set_property("default_adapter_powered", value)
+        )


### PR DESCRIPTION
Bluetooth service requires gnome-bluetooth. 

Arch: should be under the name `gnome-bluetooth-3.0`
NixOS: is under the name `gnome.gnome-bluetooth`