### PR TITLE
fix: Make Hyprland module compatible with +0.40.0

### DIFF
--- a/fabric/hyprland/service.py
+++ b/fabric/hyprland/service.py
@@ -113,6 +113,8 @@ class Hyprland(Service):
         if not os.path.isdir(hyprland_dir):
             hyprland_dir = f"{self.XDG_RUNTIME_DIR}/hypr/{self.HYPRLAND_SIGNATURE}"
             if not os.path.isdir(hyprland_dir):
+
+                # hyprland is not running
                 raise HyprlandSocketNotFoundError(
                     "Hyprland socket doesn't seem to be found,\nIs Hyprland running?"
                 )


### PR DESCRIPTION
With Hyprland v0.40.0, the `/tmp/hypr/` directory was moved to `XDG_RUNTIME_DIR/hypr/`.
This commit supports latest and previous Hyprland versions.