### PR TITLE
feat: add markup support for labels 

### DIFF
--- a/fabric/hyprland/service.py
+++ b/fabric/hyprland/service.py
@@ -113,6 +113,8 @@ class Hyprland(Service):
         if not os.path.isdir(hyprland_dir):
             hyprland_dir = f"{self.XDG_RUNTIME_DIR}/hypr/{self.HYPRLAND_SIGNATURE}"
             if not os.path.isdir(hyprland_dir):
+
+                # hyprland is not running
                 raise HyprlandSocketNotFoundError(
                     "Hyprland socket doesn't seem to be found,\nIs Hyprland running?"
                 )

--- a/fabric/widgets/label.py
+++ b/fabric/widgets/label.py
@@ -109,10 +109,12 @@ class Label(Gtk.Label, Widget):
             name,
             size,
         )
-        if markup:
-            self.set_markup(label) if label is not None else None
-        else:
-            self.set_label(label) if label is not None else None
+
+        if label is not None and markup is True:
+            self.set_markup(label)
+        elif label is not None:
+            self.set_label(label)
+
         self.set_justify(
             {
                 "left": Gtk.Justification.LEFT,

--- a/fabric/widgets/label.py
+++ b/fabric/widgets/label.py
@@ -10,6 +10,7 @@ class Label(Gtk.Label, Widget):
     def __init__(
         self,
         label: str | None = None,
+        markup: bool = False,
         justfication: Literal[
             "left",
             "right",
@@ -50,6 +51,8 @@ class Label(Gtk.Label, Widget):
         """
         :param label: the actual label text, defaults to None
         :type label: str | None, optional
+        :param markup: whether to use markup or plain text, defaults to False
+        :type markup: bool, optional
         :param justfication: justfication mode, defaults to None
         :type justfication: Literal["left", "right", "center", "fill",] | Gtk.Justification | None, optional
         :param ellipsization: ellipsization mode, defaults to None
@@ -106,7 +109,10 @@ class Label(Gtk.Label, Widget):
             name,
             size,
         )
-        self.set_label(label) if label is not None else None
+        if markup:
+            self.set_markup(label) if label is not None else None
+        else:
+            self.set_label(label) if label is not None else None
         self.set_justify(
             {
                 "left": Gtk.Justification.LEFT,


### PR DESCRIPTION
Instead of having to do `set_markup()` for every label, now you have the `markup` property which is a boolean.
By default, the label is plain text. With `markup = True` the label will now accept markup.

For example:

This code:
```python
        self.run_label = Label(
            name="run-label",
            label="<span>&#xec2c;</span>",
        )
```
Will give this result:
![imagen](https://github.com/Fabric-Development/fabric/assets/66109459/3b7fd2de-ae0c-4cb4-a10c-3bc04077de0f)

With this addition, this code:
```python
        self.run_label = Label(
            name="run-label",
            label="<span>&#xec2c;</span>",
            markup=True,
        )
```
Will give this result:
![imagen](https://github.com/Fabric-Development/fabric/assets/66109459/17094082-7e7a-4e6d-83a0-dba82466e8b1)