### PR TITLE
Add "include_hidden" parameter to get_desktop_applications function

### DIFF
--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -14,7 +14,14 @@ class Application:
         self.window_class: str | None = app.get_startup_wm_class()
         self.executable: str | None = app.get_executable()
         self.command_line: str | None = app.get_commandline()
-        self.icon: Gio.Icon | Gio.ThemedIcon | Gio.FileIcon | Gio.LoadableIcon | Gio.EmblemedIcon | None = app.get_icon()
+        self.icon: (
+            Gio.Icon
+            | Gio.ThemedIcon
+            | Gio.FileIcon
+            | Gio.LoadableIcon
+            | Gio.EmblemedIcon
+            | None
+        ) = app.get_icon()
         self.icon_name: str | None = (
             self.icon.to_string() if self.icon is not None else None
         )
@@ -83,4 +90,3 @@ def get_desktop_applications(include_hidden=False) -> list[Application]:
         for app in Gio.DesktopAppInfo.get_all()
         if include_hidden or app.should_show()
     ]
-

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -68,11 +68,13 @@ class Application:
         return self._pixbuf
 
 
-def get_desktop_applications(include_hidden = False) -> list[Application]:
+def get_desktop_applications(include_hidden=False) -> list[Application]:
     """
     get a list of all desktop applications
     this might be useful for writing application launchers
 
+    :param include_hidden: whether to include applications unintended to be visible to normal users, defaults to false
+    :type include_hidden: bool, optional
     :return: a list of all desktop applications
     :rtype: list[Application]
     """

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -68,7 +68,7 @@ class Application:
         return self._pixbuf
 
 
-def get_desktop_applications() -> list[Application]:
+def get_desktop_applications(include_hidden = False) -> list[Application]:
     """
     get a list of all desktop applications
     this might be useful for writing application launchers
@@ -76,4 +76,4 @@ def get_desktop_applications() -> list[Application]:
     :return: a list of all desktop applications
     :rtype: list[Application]
     """
-    return [Application(app) for app in Gio.DesktopAppInfo.get_all()]
+    return [Application(app) for app in Gio.DesktopAppInfo.get_all() if app.should_show() and not include_hidden]

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -14,14 +14,7 @@ class Application:
         self.window_class: str | None = app.get_startup_wm_class()
         self.executable: str | None = app.get_executable()
         self.command_line: str | None = app.get_commandline()
-        self.icon: (
-            Gio.Icon
-            | Gio.ThemedIcon
-            | Gio.FileIcon
-            | Gio.LoadableIcon
-            | Gio.EmblemedIcon
-            | None
-        ) = app.get_icon()
+        self.icon: Gio.Icon | Gio.ThemedIcon | Gio.FileIcon | Gio.LoadableIcon | Gio.EmblemedIcon | None = app.get_icon()
         self.icon_name: str | None = (
             self.icon.to_string() if self.icon is not None else None
         )
@@ -75,7 +68,7 @@ class Application:
         return self._pixbuf
 
 
-def get_desktop_applications(include_hidden=False) -> list[Application]:
+def get_desktop_applications(include_hidden: bool = False) -> list[Application]:
     """
     get a list of all desktop applications
     this might be useful for writing application launchers

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -78,12 +78,9 @@ def get_desktop_applications(include_hidden=False) -> list[Application]:
     :return: a list of all desktop applications
     :rtype: list[Application]
     """
-    return (
-        [Application(app) for app in Gio.DesktopAppInfo.get_all()]
-        if include_hidden
-        else [
-            Application(app)
-            for app in Gio.DesktopAppInfo.get_all()
-            if app.should_show()
-        ]
-    )
+    return [
+        Application(app)
+        for app in Gio.DesktopAppInfo.get_all()
+        if include_hidden or app.should_show()
+    ]
+

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -78,8 +78,12 @@ def get_desktop_applications(include_hidden=False) -> list[Application]:
     :return: a list of all desktop applications
     :rtype: list[Application]
     """
-    return [
-        Application(app)
-        for app in Gio.DesktopAppInfo.get_all()
-        if app.should_show() and not include_hidden
-    ]
+    return (
+        [Application(app) for app in Gio.DesktopAppInfo.get_all()]
+        if include_hidden
+        else [
+            Application(app)
+            for app in Gio.DesktopAppInfo.get_all()
+            if app.should_show()
+        ]
+    )

--- a/fabric/utils/applications.py
+++ b/fabric/utils/applications.py
@@ -76,4 +76,8 @@ def get_desktop_applications(include_hidden = False) -> list[Application]:
     :return: a list of all desktop applications
     :rtype: list[Application]
     """
-    return [Application(app) for app in Gio.DesktopAppInfo.get_all() if app.should_show() and not include_hidden]
+    return [
+        Application(app)
+        for app in Gio.DesktopAppInfo.get_all()
+        if app.should_show() and not include_hidden
+    ]


### PR DESCRIPTION
Default behavior of get_desktop_applications should only include applications that the user should want to click. By [default](https://docs.gtk.org/gio/type_func.AppInfo.get_all.html), `Gio.AppInfo.GetAll` will return all applications, even those that should not be shown to the user. 