### PR TITLE
feat: Add Nix flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,7 @@
   gobject-introspection,
   libdbusmenu-gtk3,
   gdk-pixbuf,
+  cinnamon,
   gnome,
 }:
 
@@ -24,6 +25,7 @@ python311Packages.buildPythonPackage {
     gobject-introspection
     libdbusmenu-gtk3
     gdk-pixbuf
+    cinnamon.cinnamon-desktop
     gnome.gnome-bluetooth
   ];
 

--- a/default.nix
+++ b/default.nix
@@ -34,6 +34,7 @@ python311Packages.buildPythonPackage {
     click
     pycairo
     pygobject3
+    pygobject-stubs
     loguru
     psutil
   ];

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@
 }:
 
 python311Packages.buildPythonPackage {
-  pname = "fabric";
+  pname = "python-fabric";
   version = "0.0.1";
   pyproject = true;
 

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,16 @@
-{ lib
-, python311Packages
-, gtk3
-, gtk-layer-shell
-, cairo
-, gobject-introspection
-, libdbusmenu-gtk3
-, gdk-pixbuf
-, gnome
+{
+  lib,
+  python311Packages,
+  gtk3,
+  gtk-layer-shell,
+  cairo,
+  gobject-introspection,
+  libdbusmenu-gtk3,
+  gdk-pixbuf,
+  gnome,
 }:
 
-python311Packages.buildPythonPackage rec {
+python311Packages.buildPythonPackage {
   pname = "fabric";
   version = "0.0.1";
   pyproject = true;
@@ -38,10 +39,10 @@ python311Packages.buildPythonPackage rec {
   meta = {
     changelog = "";
     description = ''
-    next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
+      next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
     '';
     homepage = "https://github.com/Fabric-Development/fabric";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,47 @@
+{ lib
+, python311Packages
+, gtk3
+, gtk-layer-shell
+, cairo
+, gobject-introspection
+, libdbusmenu-gtk3
+, gdk-pixbuf
+, gnome
+}:
+
+python311Packages.buildPythonPackage rec {
+  pname = "fabric";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = ./.;
+
+  buildInputs = [
+    gtk3
+    gtk-layer-shell
+    cairo
+    gobject-introspection
+    libdbusmenu-gtk3
+    gdk-pixbuf
+    gnome.gnome-bluetooth
+  ];
+
+  dependencies = with python311Packages; [
+    setuptools
+    click
+    pycairo
+    pygobject3
+    loguru
+    psutil
+  ];
+
+  meta = {
+    changelog = "";
+    description = ''
+    next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
+    '';
+    homepage = "https://github.com/Fabric-Development/fabric";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1724819573,
+        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -16,26 +16,9 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1724819573,
-        "narHash": "sha256-GnR7/ibgIH1vhoy8cYdmXE6iyZqKqFxQSVkFgosBh6w=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
         "utils": "utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
                   loguru
                   psutil
                   fabric-widgets
+                  pygobject-stubs
                 ]
               );
             in
@@ -90,6 +91,7 @@
                   click
                   pycairo
                   pygobject3
+                  pygobject-stubs
                   loguru
                   psutil
                   fabric-widgets

--- a/flake.nix
+++ b/flake.nix
@@ -1,72 +1,63 @@
 {
   description = ''
-    next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
+    next-gen framework for building desktop widgets using Python
+    (check the rewrite branch for progress)
   '';
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/24.05";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    nixpkgs,
-    nixpkgs-unstable,
-    utils,
-    ...
-  }:
-    utils.lib.eachDefaultSystem
-    (system: let
-      overlay = final: prev: {
-        pythonPackagesExtensions =
-          prev.pythonPackagesExtensions
-          ++ [
-            (
-              python-final: python-prev: {
-                fabric-widgets = prev.callPackage ./default.nix {};
-              }
-            )
-          ];
-      };
-
-      pkgs = nixpkgs.legacyPackages.${system}.extend overlay;
-      unstable-pkgs = nixpkgs-unstable.legacyPackages.${system};
-
-      pythonWithPackages = pkgs.python3.withPackages (ps:
-        with ps; [
-          setuptools
-          wheel
-          build
-          click
-          pycairo
-          pygobject3
-          loguru
-          psutil
-          fabric-widgets
-        ]);
-    in {
-      packages = {
-        default = pkgs.python3Packages.fabric-widgets;
-      };
-
-      overlays.default = overlay;
-
-      devShells = {
-        default = pkgs.mkShell {
-          name = "fabric-shell";
-          packages = [
-            unstable-pkgs.basedpyright
-            unstable-pkgs.ruff
-            pythonWithPackages
-            pkgs.gtk3
-            pkgs.gtk-layer-shell
-            pkgs.cairo
-            pkgs.gobject-introspection
-            pkgs.libdbusmenu-gtk3
-            pkgs.gdk-pixbuf
-            pkgs.gnome.gnome-bluetooth
+  outputs =
+    { nixpkgs, utils, ... }:
+    utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlay = final: prev: {
+          pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+            (python-final: python-prev: {
+              # `fabric` was taken
+              fabric-widgets = prev.callPackage ./default.nix { };
+            })
           ];
         };
-      };
-    });
+
+        pkgs = nixpkgs.legacyPackages.${system}.extend overlay;
+      in
+      {
+        packages.default = pkgs.python3Packages.fabric-widgets;
+        overlays.default = overlay;
+        formatter = pkgs.nixfmt-rfc-style;
+
+        devShells = {
+          default = pkgs.mkShell {
+            name = "fabric-shell";
+            packages = with pkgs; [
+              ruff
+              gtk3
+              gtk-layer-shell
+              cairo
+              gobject-introspection
+              libdbusmenu-gtk3
+              gdk-pixbuf
+              gnome.gnome-bluetooth
+              (python3.withPackages (
+                ps: with ps; [
+                  setuptools
+                  wheel
+                  build
+                  click
+                  pycairo
+                  pygobject3
+                  loguru
+                  psutil
+                  fabric-widgets
+                ]
+              ))
+            ];
+          };
+        };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,7 @@
         overlay = final: prev: {
           pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
             (python-final: python-prev: {
-              # `fabric` was taken
-              fabric-widgets = prev.callPackage ./default.nix { };
+              python-fabric = prev.callPackage ./default.nix { };
             })
           ];
         };
@@ -29,18 +28,17 @@
         overlays.default = overlay;
         formatter = pkgs.nixfmt-rfc-style;
         packages = {
-          default = pkgs.python3Packages.fabric-widgets;
+          default = pkgs.python3Packages.python-fabric ;
           run-widget =
             let
               python = pkgs.python3.withPackages (
                 ps: with ps; [
-                  fabric-widgets
                   click
                   pycairo
                   pygobject3
                   loguru
                   psutil
-                  fabric-widgets
+                  python-fabric
                   pygobject-stubs
                 ]
               );
@@ -94,7 +92,7 @@
                   pygobject-stubs
                   loguru
                   psutil
-                  fabric-widgets
+                  python-fabric
                 ]
               ))
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = ''
+  next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
+  '';
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/24.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-unstable,
+    utils,
+    ...
+  }:
+    utils.lib.eachDefaultSystem
+    (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      unstable-pkgs = nixpkgs-unstable.legacyPackages.${system};
+
+      pythonWithPackages = pkgs.python311.withPackages (ps: with ps; [
+        setuptools
+        wheel
+        build
+        click
+        pycairo
+        pygobject3
+        loguru
+        psutil
+        self.packages.${system}.default
+        ]);
+    in {
+      packages = {
+        default = pkgs.callPackage ./default.nix { };
+      };
+      apps = {
+      };
+      devShells = {
+        default = pkgs.mkShell {
+          name = "fabric-shell";
+          packages = [
+            unstable-pkgs.basedpyright
+            unstable-pkgs.ruff
+            pythonWithPackages
+            pkgs.gtk3
+            pkgs.gtk-layer-shell
+            pkgs.cairo
+            pkgs.gobject-introspection
+            pkgs.libdbusmenu-gtk3
+            pkgs.gdk-pixbuf
+            pkgs.gnome.gnome-bluetooth
+          ];
+        };
+      };
+    });
+}
+
+


### PR DESCRIPTION
Enables building and running on systems using the Nix package manager.

Tested with all examples within the repository.


Also 9b5da59 resolves #25 (I use NixOS as well). People will most likely have a better experience 
by building via [buildPythonApplication](https://nixos.org/manual/nixpkgs/stable/#buildpythonapplication-function) and adding this flake's python package as a dependency.

