### PR TITLE
feat: add notifications service

### DIFF
--- a/examples/notifications/notifications.py
+++ b/examples/notifications/notifications.py
@@ -1,0 +1,162 @@
+from typing import cast
+
+from fabric import Application
+from fabric.widgets.box import Box
+from fabric.widgets.label import Label
+from fabric.widgets.image import Image
+from fabric.widgets.button import Button
+from fabric.widgets.wayland import WaylandWindow
+from fabric.notifications import Notifications, Notification
+from fabric.utils import invoke_repeater, get_relative_path
+
+from gi.repository import GdkPixbuf
+
+
+NOTIFICATION_WIDTH = 360
+NOTIFICATION_IMAGE_SIZE = 64
+NOTIFICATION_TIMEOUT = 10 * 1000  # 10 seconds
+
+
+class NotificationWidget(Box):
+    def __init__(self, notification: Notification, **kwargs):
+        super().__init__(
+            size=(NOTIFICATION_WIDTH, -1),
+            name="notification",
+            spacing=8,
+            orientation="v",
+            **kwargs,
+        )
+
+        self._notification = notification
+
+        body_container = Box(spacing=4, orientation="h")
+
+        if image_pixbuf := self._notification.image_pixbuf:
+            body_container.add(
+                Image(
+                    pixbuf=image_pixbuf.scale_simple(
+                        NOTIFICATION_IMAGE_SIZE,
+                        NOTIFICATION_IMAGE_SIZE,
+                        GdkPixbuf.InterpType.BILINEAR,
+                    )
+                )
+            )
+
+        body_container.add(
+            Box(
+                spacing=4,
+                orientation="v",
+                children=[
+                    # a box for holding both the "summary" label and the "close" button
+                    Box(
+                        orientation="h",
+                        children=[
+                            Label(
+                                label=self._notification.summary,
+                                ellipsization="middle",
+                            )
+                            .build()
+                            .add_style_class("summary")
+                            .unwrap(),
+                        ],
+                        h_expand=True,
+                        v_expand=True,
+                    )
+                    # add the "close" button
+                    .build(
+                        lambda box, _: box.pack_end(
+                            Button(
+                                image=Image(
+                                    icon_name="close-symbolic",
+                                    icon_size=18,
+                                ),
+                                v_align="center",
+                                h_align="end",
+                                on_clicked=lambda *_: self._notification.close(),
+                            ),
+                            False,
+                            False,
+                            0,
+                        )
+                    ),
+                    Label(
+                        label=self._notification.body,
+                        line_wrap="word-char",
+                        v_align="start",
+                        h_align="start",
+                    )
+                    .build()
+                    .add_style_class("body")
+                    .unwrap(),
+                ],
+                h_expand=True,
+                v_expand=True,
+            )
+        )
+
+        self.add(body_container)
+
+        if actions := self._notification.actions:
+            self.add(
+                Box(
+                    spacing=4,
+                    orientation="h",
+                    children=[
+                        Button(
+                            h_expand=True,
+                            v_expand=True,
+                            label=action.label,
+                            on_clicked=lambda *_, action=action: action.invoke(),
+                        )
+                        for action in actions
+                    ],
+                )
+            )
+
+        # destroy this widget once the notification is closed
+        self._notification.connect(
+            "closed",
+            lambda *_: (
+                parent.remove(self) if (parent := self.get_parent()) else None,  # type: ignore
+                self.destroy(),
+            ),
+        )
+
+        # automatically close the notification after the timeout period
+        invoke_repeater(
+            NOTIFICATION_TIMEOUT,
+            lambda: self._notification.close("expired"),
+            initial_call=False,
+        )
+
+
+if __name__ == "__main__":
+    app = Application(
+        "notifications",
+        WaylandWindow(
+            margin="8px 8px 8px 8px",
+            anchor="top right",
+            child=Box(
+                size=2,  # so it's not ignored by the compositor
+                spacing=4,
+                orientation="v",
+            ).build(
+                lambda viewport, _: Notifications(
+                    on_notification_added=lambda notifs_service, nid: viewport.add(
+                        NotificationWidget(
+                            cast(
+                                Notification,
+                                notifs_service.get_notification_from_id(nid),
+                            )
+                        )
+                    )
+                )
+            ),
+            visible=True,
+            all_visible=True,
+        ),
+    )
+
+    app.set_stylesheet_from_file(get_relative_path("./style.css"))
+
+    app.run()

--- a/examples/notifications/style.css
+++ b/examples/notifications/style.css
@@ -1,0 +1,40 @@
+:vars {
+    --foreground: rgb(255, 255, 255);
+    --background: rgb(26, 28, 30);
+    --border-color: rgb(42, 43, 45);
+    --button-color: var(--border-color);
+}
+
+* {
+    all: unset;
+    color: var(--foreground);
+    font-family: "Jost*", "Cantarell", "Helvetica", "Arial", sans-serif;
+}
+
+#notification {
+    padding: 0.8rem;
+    border: solid 1px var(--border-color);
+    border-radius: 1rem;
+    background-color: var(--background);
+}
+
+#notification .summary {
+    font-size: 20px;
+    font-weight: bold;
+}
+
+#notification .body {
+    color: darker(var(--foreground));
+    font-weight: normal;
+}
+
+button {
+    padding: 0.6rem;
+    font-weight: 600;
+    border-radius: 3rem;
+    background-color: var(--button-color);
+}
+
+button:hover {
+    background-color: lighter(var(--button-color));
+}

--- a/fabric/dbus_assets/org.Fabric.fabric.xml
+++ b/fabric/dbus_assets/org.Fabric.fabric.xml
@@ -1,30 +1,30 @@
 <node name="/org/Fabric/fabric">
-  <interface name="org.freedesktop.DBus.Peer">
-    <method name="Ping"/>
-    <method name="GetMachineId">
-    <arg direction="out" type="s" name="machine_uuid" />
-    </method>
-  </interface>
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg direction="out" type="s" />
-    </method>
-  </interface>
-  <interface name="org.Fabric.fabric">
-    <property name="Windows" type="a{sb}" access="read"/>
-    <property name="File" type="s" access="read"/>
-    <method name="Execute">
-      <arg direction="in"  type="s" name="source" />
-      <arg direction="out" type="s" />
-    </method>    
-    <method name="Evaluate">
-      <arg direction="in"  type="s" name="code" />
-      <arg direction="out" type="s" />
-      <arg direction="out" type="s" />
-    </method>
-    <method name="Log">
-      <arg direction="in"  type="y" name="level" />
-      <arg direction="in"  type="s" name="message" />
-    </method>
-  </interface>
+	<interface name="org.freedesktop.DBus.Peer">
+		<method name="Ping" />
+		<method name="GetMachineId">
+			<arg direction="out" type="s" name="machine_uuid" />
+		</method>
+	</interface>
+	<interface name="org.freedesktop.DBus.Introspectable">
+		<method name="Introspect">
+			<arg direction="out" type="s" />
+		</method>
+	</interface>
+	<interface name="org.Fabric.fabric">
+		<property name="Windows" type="a{sb}" access="read" />
+		<property name="File" type="s" access="read" />
+		<method name="Execute">
+			<arg direction="in" type="s" name="source" />
+			<arg direction="out" type="s" />
+		</method>
+		<method name="Evaluate">
+			<arg direction="in" type="s" name="code" />
+			<arg direction="out" type="s" />
+			<arg direction="out" type="s" />
+		</method>
+		<method name="Log">
+			<arg direction="in" type="y" name="level" />
+			<arg direction="in" type="s" name="message" />
+		</method>
+	</interface>
 </node>

--- a/fabric/dbus_assets/org.freedesktop.Notifications.xml
+++ b/fabric/dbus_assets/org.freedesktop.Notifications.xml
@@ -1,0 +1,36 @@
+<node>
+	<interface name="org.freedesktop.Notifications">
+		<signal name="NotificationClosed">
+			<arg name="id" type="u" direction="out" />
+			<arg name="reason" type="u" direction="out" />
+		</signal>
+		<signal name="ActionInvoked">
+			<arg name="id" type="u" direction="out" />
+			<arg name="action_key" type="s" direction="out" />
+		</signal>
+		<method name="Notify">
+			<annotation name="org.qtproject.QtDBus.QtTypeName.In6" value="QVariantMap" />
+			<arg type="u" direction="out" />
+			<arg name="app_name" type="s" direction="in" />
+			<arg name="replaces_id" type="u" direction="in" />
+			<arg name="app_icon" type="s" direction="in" />
+			<arg name="summary" type="s" direction="in" />
+			<arg name="body" type="s" direction="in" />
+			<arg name="actions" type="as" direction="in" />
+			<arg name="hints" type="a{sv}" direction="in" />
+			<arg name="timeout" type="i" direction="in" />
+		</method>
+		<method name="CloseNotification">
+			<arg name="id" type="u" direction="in" />
+		</method>
+		<method name="GetCapabilities">
+			<arg type="as" name="caps" direction="out" />
+		</method>
+		<method name="GetServerInformation">
+			<arg type="s" name="name" direction="out" />
+			<arg type="s" name="vendor" direction="out" />
+			<arg type="s" name="version" direction="out" />
+			<arg type="s" name="spec_version" direction="out" />
+		</method>
+	</interface>
+</node>

--- a/fabric/dbus_assets/org.kde.StatusNotifierItem.xml
+++ b/fabric/dbus_assets/org.kde.StatusNotifierItem.xml
@@ -1,50 +1,47 @@
 <node>
-    <interface name="org.kde.StatusNotifierItem">
-        <property name="Category" type="s" access="read"/>
-        <property name="Id" type="s" access="read"/>
-        <property name="Title" type="s" access="read"/>
-        <property name="Status" type="s" access="read"/>
-        <property name="WindowId" type="i" access="read"/>
-        <property name="IconThemePath" type="s" access="read"/>
-        <property name="ItemIsMenu" type="b" access="read"/>
-        <property name="Menu" type="o" access="read"/>
-        <property name="IconName" type="s" access="read"/>
-        <property name="IconPixmap" type="a(iiay)" access="read">
-            <annotation name="org.qtproject.QtDBus.QtTypeName"
-                        value="KDbusImageVector"/>
-        </property>
-        <property name="AttentionIconName" type="s" access="read"/>
-        <property name="AttentionIconPixmap" type="a(iiay)" access="read">
-            <annotation name="org.qtproject.QtDBus.QtTypeName"
-                        value="KDbusImageVector"/>
-        </property>
-        <property name="ToolTip" type="(sa(iiay)ss)" access="read">
-            <annotation name="org.qtproject.QtDBus.QtTypeName"
-                        value="KDbusToolTipStruct"/>
-        </property>
-        <method name="ContextMenu">
-            <arg name="x" type="i" direction="in"/>
-            <arg name="y" type="i" direction="in"/>
-        </method>
-        <method name="Activate">
-            <arg name="x" type="i" direction="in"/>
-            <arg name="y" type="i" direction="in"/>
-        </method>
-        <method name="SecondaryActivate">
-            <arg name="x" type="i" direction="in"/>
-            <arg name="y" type="i" direction="in"/>
-        </method>
-        <method name="Scroll">
-            <arg name="delta" type="i" direction="in"/>
-            <arg name="orientation" type="s" direction="in"/>
-        </method>
-        <signal name="NewTitle"/>
-        <signal name="NewIcon"/>
-        <signal name="NewAttentionIcon"/>
-        <signal name="NewOverlayIcon"/>
-        <signal name="NewToolTip"/>
-        <signal name="NewStatus">
-            <arg name="status" type="s"/>
-        </signal>
-    </interface>
+	<interface name="org.kde.StatusNotifierItem">
+		<property name="Category" type="s" access="read" />
+		<property name="Id" type="s" access="read" />
+		<property name="Title" type="s" access="read" />
+		<property name="Status" type="s" access="read" />
+		<property name="WindowId" type="i" access="read" />
+		<property name="IconThemePath" type="s" access="read" />
+		<property name="ItemIsMenu" type="b" access="read" />
+		<property name="Menu" type="o" access="read" />
+		<property name="IconName" type="s" access="read" />
+		<property name="IconPixmap" type="a(iiay)" access="read">
+			<annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusImageVector" />
+		</property>
+		<property name="AttentionIconName" type="s" access="read" />
+		<property name="AttentionIconPixmap" type="a(iiay)" access="read">
+			<annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusImageVector" />
+		</property>
+		<property name="ToolTip" type="(sa(iiay)ss)" access="read">
+			<annotation name="org.qtproject.QtDBus.QtTypeName" value="KDbusToolTipStruct" />
+		</property>
+		<method name="ContextMenu">
+			<arg name="x" type="i" direction="in" />
+			<arg name="y" type="i" direction="in" />
+		</method>
+		<method name="Activate">
+			<arg name="x" type="i" direction="in" />
+			<arg name="y" type="i" direction="in" />
+		</method>
+		<method name="SecondaryActivate">
+			<arg name="x" type="i" direction="in" />
+			<arg name="y" type="i" direction="in" />
+		</method>
+		<method name="Scroll">
+			<arg name="delta" type="i" direction="in" />
+			<arg name="orientation" type="s" direction="in" />
+		</method>
+		<signal name="NewTitle" />
+		<signal name="NewIcon" />
+		<signal name="NewAttentionIcon" />
+		<signal name="NewOverlayIcon" />
+		<signal name="NewToolTip" />
+		<signal name="NewStatus">
+			<arg name="status" type="s" />
+		</signal>
+	</interface>
 </node>

--- a/fabric/dbus_assets/org.kde.StatusNotifierWatcher.xml
+++ b/fabric/dbus_assets/org.kde.StatusNotifierWatcher.xml
@@ -1,36 +1,35 @@
 <node>
-    <interface name="org.kde.StatusNotifierWatcher">
-        <annotation name="org.gtk.GDBus.C.Name" value="Watcher" />
-        <method name="RegisterStatusNotifierItem">
-            <annotation name="org.gtk.GDBus.C.Name" value="RegisterItem" />
-            <arg name="service" type="s" direction="in"/>
-        </method>
-        <method name="RegisterStatusNotifierHost">
-            <annotation name="org.gtk.GDBus.C.Name" value="RegisterHost" />
-            <arg name="service" type="s" direction="in"/>
-        </method>
-        <property name="RegisteredStatusNotifierItems" type="as" access="read">
-            <annotation name="org.gtk.GDBus.C.Name" value="RegisteredItems" />
-            <annotation name="org.qtproject.QtDBus.QtTypeName.Out0"
-                        value="QStringList"/>
-        </property>
-        <property name="IsStatusNotifierHostRegistered" type="b" access="read">
-            <annotation name="org.gtk.GDBus.C.Name" value="IsHostRegistered" />
-        </property>
-        <property name="ProtocolVersion" type="i" access="read"/>
-        <signal name="StatusNotifierItemRegistered">
-            <annotation name="org.gtk.GDBus.C.Name" value="ItemRegistered" />
-            <arg type="s" direction="out" name="service" />
-        </signal>
-        <signal name="StatusNotifierItemUnregistered">
-            <annotation name="org.gtk.GDBus.C.Name" value="ItemUnregistered" />
-            <arg type="s" direction="out" name="service" />
-        </signal>
-        <signal name="StatusNotifierHostRegistered">
-            <annotation name="org.gtk.GDBus.C.Name" value="HostRegistered" />
-        </signal>
-        <signal name="StatusNotifierHostUnregistered">
-            <annotation name="org.gtk.GDBus.C.Name" value="HostUnregistered" />
-        </signal>
-    </interface>
+	<interface name="org.kde.StatusNotifierWatcher">
+		<annotation name="org.gtk.GDBus.C.Name" value="Watcher" />
+		<method name="RegisterStatusNotifierItem">
+			<annotation name="org.gtk.GDBus.C.Name" value="RegisterItem" />
+			<arg name="service" type="s" direction="in" />
+		</method>
+		<method name="RegisterStatusNotifierHost">
+			<annotation name="org.gtk.GDBus.C.Name" value="RegisterHost" />
+			<arg name="service" type="s" direction="in" />
+		</method>
+		<property name="RegisteredStatusNotifierItems" type="as" access="read">
+			<annotation name="org.gtk.GDBus.C.Name" value="RegisteredItems" />
+			<annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QStringList" />
+		</property>
+		<property name="IsStatusNotifierHostRegistered" type="b" access="read">
+			<annotation name="org.gtk.GDBus.C.Name" value="IsHostRegistered" />
+		</property>
+		<property name="ProtocolVersion" type="i" access="read" />
+		<signal name="StatusNotifierItemRegistered">
+			<annotation name="org.gtk.GDBus.C.Name" value="ItemRegistered" />
+			<arg type="s" direction="out" name="service" />
+		</signal>
+		<signal name="StatusNotifierItemUnregistered">
+			<annotation name="org.gtk.GDBus.C.Name" value="ItemUnregistered" />
+			<arg type="s" direction="out" name="service" />
+		</signal>
+		<signal name="StatusNotifierHostRegistered">
+			<annotation name="org.gtk.GDBus.C.Name" value="HostRegistered" />
+		</signal>
+		<signal name="StatusNotifierHostUnregistered">
+			<annotation name="org.gtk.GDBus.C.Name" value="HostUnregistered" />
+		</signal>
+	</interface>
 </node>

--- a/fabric/notifications/__init__.py
+++ b/fabric/notifications/__init__.py
@@ -1,0 +1,18 @@
+from .service import (
+    Notifications,
+    Notification,
+    NotificationAction,
+    NotificationImagePixmap,
+    NotificationCloseReason,
+    NotificationSerializedData,
+)
+
+
+__all__ = [
+    "Notifications",
+    "Notification",
+    "NotificationAction",
+    "NotificationImagePixmap",
+    "NotificationCloseReason",
+    "NotificationSerializedData",
+]

--- a/fabric/notifications/service.py
+++ b/fabric/notifications/service.py
@@ -1,0 +1,285 @@
+import gi
+from enum import Enum
+from typing import cast
+from fabric.core.service import Service, Signal, Property
+from fabric.utils.helpers import load_dbus_xml
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gio, GLib, GdkPixbuf
+
+
+NOTIFICATIONS_BUS_NAME = "org.freedesktop.Notifications"
+NOTIFICATIONS_BUS_PATH = "/org/freedesktop/Notifications"
+NOTIFICATIONS_BUS_IFACE_NODE = load_dbus_xml(
+    "../dbus_assets/org.freedesktop.Notifications.xml",
+)
+
+
+class NotificationCloseReason(Enum):
+    EXPIRED = 1
+    DISMISSED_BY_USER = 2
+    CLOSED_BY_APPLICATION = 3
+    UNKNOWN = 4
+
+
+class NotificationImagePixmap:
+    def __init__(self, raw_variant: GLib.Variant):
+        # manually unpack children so we don't lock up the interpreter
+        # trying to unpack hugely sized object recursively
+        self.width = raw_variant.get_child_value(0).unpack()  # type: ignore
+        self.height = raw_variant.get_child_value(1).unpack()  # type: ignore
+        self.rowstride = raw_variant.get_child_value(2).unpack()  # type: ignore
+        self.has_alpha = raw_variant.get_child_value(3).unpack()  # type: ignore
+        self.bits_per_sample = raw_variant.get_child_value(4).unpack()  # type: ignore
+        self.channels = raw_variant.get_child_value(5).unpack()  # type: ignore
+        self.byte_array = raw_variant.get_child_value(6).get_data_as_bytes()  # type: ignore
+
+        self._pixbuf: GdkPixbuf.Pixbuf | None = None
+
+    def as_pixbuf(self) -> GdkPixbuf.Pixbuf:
+        if self._pixbuf is not None:
+            return self._pixbuf
+
+        self._pixbuf = GdkPixbuf.Pixbuf.new_from_bytes(
+            self.byte_array,
+            GdkPixbuf.Colorspace.RGB,
+            self.has_alpha,
+            self.bits_per_sample,
+            self.width,
+            self.height,
+            self.rowstride,
+        )
+        return self._pixbuf
+
+
+class Notification(Service):
+    @Property(str, "readable")
+    def app_name(self) -> str:
+        return self._app_name
+
+    @Property(str, "readable")
+    def app_icon(self) -> str:
+        return self._app_icon
+
+    @Property(str, "readable")
+    def summary(self) -> str:
+        return self._summary
+
+    @Property(str, "readable")
+    def body(self) -> str:
+        return self._body
+
+    @Property(int, "readable")
+    def id(self) -> int:
+        return self._id
+
+    @Property(int, "readable")
+    def replaces_id(self) -> int:
+        return self._replaces_id
+
+    @Property(int, "readable")
+    def timeout(self) -> int:
+        return self._timeout
+
+    @Property(NotificationImagePixmap, "readable")
+    def image_pixmap(self) -> NotificationImagePixmap:
+        return self._image_pixmap  # type: ignore
+
+    @Property(str, "readable")
+    def image_file(self) -> str:
+        return self._image_file  # type: ignore
+
+    def __init__(self, raw_variant: GLib.Variant, id: int, **kwarg):
+        super().__init__(**kwarg)
+        self._id: int = id
+
+        self._app_name: str = raw_variant.get_child_value(0).unpack()  # type: ignore
+        self._replaces_id: int = raw_variant.get_child_value(1).unpack()  # type: ignore
+        self._app_icon: str = raw_variant.get_child_value(2).unpack()  # type: ignore
+        self._summary: str = raw_variant.get_child_value(3).unpack()  # type: ignore
+        self._body: str = raw_variant.get_child_value(4).unpack()  # type: ignore
+        self._actions: list[str] = raw_variant.get_child_value(5).unpack()  # type: ignore
+        self._hints: GLib.Variant = raw_variant.get_child_value(6)  # type: ignore
+        self._timeout: int = raw_variant.get_child_value(7).unpack()  # type: ignore
+
+        self._image_file: str | None = (
+            image_file_raw := (
+                self.do_get_hint_entry("image-path")
+                or self.do_get_hint_entry("image_path")
+            ),
+            image_file_raw.unpack() if image_file_raw is not None else None,  # type: ignore
+        )[1]
+
+        self._image_pixmap: NotificationImagePixmap | None = None
+        if image_data := (
+            self.do_get_hint_entry("image-data") or self.do_get_hint_entry("icon_data")
+        ):
+            self._image_pixmap = NotificationImagePixmap(image_data)
+
+    def do_get_hint_entry(self, entry_key: str) -> GLib.Variant | None:
+        return self._hints.lookup_value(entry_key)
+
+    def get_image_pixbuf(self) -> GdkPixbuf.Pixbuf | None:
+        if self.image_pixmap:
+            return self.image_pixmap.as_pixbuf()
+        if self.image_file:
+            return GdkPixbuf.Pixbuf.new_from_file(self.image_file)
+        return None
+
+
+class Notifications(Service):
+    @Signal
+    def changed(self) -> None: ...
+
+    @Signal
+    def notification_added(self, notification_id: int) -> None:
+        self.notify("notifications")
+        self.changed()
+        return
+
+    @Signal
+    def notification_removed(self, notification_id: int) -> None:
+        self._notifications.pop(notification_id, None)
+        self.notify("notifications")
+        self.changed()
+        return
+
+    @Signal
+    def notification_closed(self, notification_id: int, reason: object) -> None:
+        self.notification_removed(notification_id)
+        self.do_emit_bus_signal(
+            "NotificationClosed",
+            GLib.Variant.new(
+                "(ii)", notification_id, cast(NotificationCloseReason, reason).value
+            ),
+        )
+        return
+
+    @Property(dict[int, Notification], "readable")
+    def notifications(self) -> dict[int, Notification]:
+        return self._notifications
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._notifications: dict[int, Notification] = {}
+        self._connection: Gio.DBusConnection | None = None
+
+        self._counter = 0
+
+        # all aboard...
+        self.do_register()
+
+    def new_notification_id(self) -> int:
+        self._counter += 1
+        return self._counter
+
+    def do_register(self) -> int:  # the bus id
+        return Gio.bus_own_name(
+            Gio.BusType.SESSION,
+            NOTIFICATIONS_BUS_NAME,
+            Gio.BusNameOwnerFlags.NONE,
+            self.on_bus_acquired,
+            # FIXME: add logging
+            print,
+            print,
+        )
+
+    def on_bus_acquired(
+        self, conn: Gio.DBusConnection, name: str, user_data: object = None
+    ) -> None:
+        self._connection = conn
+        # we now own the name
+        for interface in NOTIFICATIONS_BUS_IFACE_NODE.interfaces:
+            cast(Gio.DBusInterface, interface)
+            if interface.name == name:
+                conn.register_object(
+                    NOTIFICATIONS_BUS_PATH,
+                    interface,
+                    self.do_handle_bus_call,  # type: ignore
+                )
+        return
+
+    def do_handle_bus_call(
+        self,
+        conn: Gio.DBusConnection,
+        sender: str,
+        path: str,
+        interface: str,
+        target: str,
+        params: tuple,
+        invocation: Gio.DBusMethodInvocation,
+        user_data: object = None,
+    ) -> None:
+        match target:
+            case "Get":
+                prop_name = params[1] if len(params) >= 1 else None
+                match prop_name:
+                    case _:
+                        invocation.return_value(None)
+            case "GetAll":
+                invocation.return_value(GLib.Variant("(a{sv})", ({},)))
+
+            case "CloseNotification":
+                notif_id = int(params[0])
+
+                self.notification_removed(notif_id)
+
+                invocation.return_value(None)
+
+            case "GetCapabilities":
+                invocation.return_value(
+                    GLib.Variant(
+                        "as",
+                        [
+                            "action-icons",
+                            "actions",
+                            "body",
+                            "body-hyperlinks",
+                            "body-images",
+                            "body-markup",
+                            # "icon-multi",
+                            "icon-static",
+                            "persistence",
+                            # "sound",
+                        ],
+                    )
+                )
+
+            case "GetServerInformation":
+                invocation.return_value(
+                    GLib.Variant(
+                        "(ssss)",
+                        ("fabric", "Fabric-Development", "0.0.2", "1.2"),
+                    )
+                )
+
+            case "Notify":
+                notif_id = self.new_notification_id()
+
+                self._notifications[notif_id] = Notification(
+                    cast(GLib.Variant, params),
+                    notif_id,
+                )
+                self.notification_added(notif_id)
+
+                invocation.return_value(GLib.Variant("(u)", (notif_id,)))
+
+        return conn.flush()
+
+    def do_emit_bus_signal(self, signal_name: str, params: GLib.Variant) -> None:
+        self._connection.emit_signal(
+            None,
+            NOTIFICATIONS_BUS_PATH,
+            NOTIFICATIONS_BUS_NAME,
+            signal_name,
+            params,
+        ) if self._connection is not None else None
+        return
+
+    def invoke_notification_action(self, notification_id: int, action: str):
+        return self.do_emit_bus_signal(
+            "ActionInvoked", GLib.Variant.new("(is)", notification_id, action)
+        )
+
+    def get_notification_from_id(self, notification_id: int) -> Notification | None:
+        return self._notifications.get(notification_id)


### PR DESCRIPTION
Implements a service for handling "Desktop Notifications", enabling users a way of defining notification daemons within Fabric.

> [!NOTE]
> Might not get merged before #43