### PR TITLE
fix:  backport for Python 3.11

### DIFF
--- a/fabric/__main__.py
+++ b/fabric/__main__.py
@@ -114,7 +114,7 @@ def list_all(json: bool = False):
         # print(dbus_name)
         proxy = get_instance_proxy(dbus_name)
         click.echo(
-            f"{config_name}: {str(proxy.get_cached_property("File").unpack())}"
+            f"{config_name}: {str(proxy.get_cached_property('File').unpack())}"
         ) if proxy is not None else None
     return
 


### PR DESCRIPTION
attempting to use `python -m fabric` would result in the following error:

```
    f"{config_name}: {str(proxy.get_cached_property("File").unpack())}"
                                                     ^^^^
SyntaxError: f-string: unmatched '('
```

replacing the double quotes with single quotes fixes this issue 