### PR TITLE
feat: add missing properties to circular progress

### DIFF
--- a/fabric/core/service.py
+++ b/fabric/core/service.py
@@ -1,33 +1,32 @@
 # GObject must be imported first so the overrides can be imported
-from collections.abc import Callable
-from dataclasses import dataclass
-from typing import (
-    Any,
-    Concatenate,
-    Generator,
-    Generic,
-    Literal,
-    Optional,
-    ParamSpec,
-    Self,
-    TypeVar,
-    Union,
-    overload,
-)
-
-import gi._propertyhelper
-import gi._signalhelper
+from gi.repository import GObject
 
 # all aboard...
 import gi.overrides
+import gi._signalhelper
+import gi._propertyhelper
 import gi.overrides.GObject
-from gi.repository import GObject
 
+from dataclasses import dataclass
+from collections.abc import Callable
+from typing import (
+    overload,
+    Concatenate,
+    ParamSpec,
+    Generator,
+    Optional,
+    Generic,
+    TypeVar,
+    Literal,
+    Union,
+    Self,
+    Any,
+)
 from fabric.utils.helpers import (
     get_enum_member,
-    get_function_annotations,
-    kebab_case_to_snake_case,
     snake_case_to_kebab_case,
+    kebab_case_to_snake_case,
+    get_function_annotations,
 )
 
 OldSignal = gi._signalhelper.Signal
@@ -437,10 +436,8 @@ class Service(OldGObject, Generic[P, T]):
         target_object: GObject.Object,
         transform_to: Callable[[GObject.Binding, Any], Any] | None = None,
         transform_from: Callable[[GObject.Binding, Any], Any] | None = None,
-        flags: (
-            Literal["default", "bidirectional", "sync-create", "invert-boolean"]
-            | GObject.BindingFlags
-        ) = GObject.BindingFlags.DEFAULT,
+        flags: Literal["default", "bidirectional", "sync-create", "invert-boolean"]
+        | GObject.BindingFlags = GObject.BindingFlags.DEFAULT,
     ):
         return self.bind_property(
             source_property,

--- a/fabric/core/service.py
+++ b/fabric/core/service.py
@@ -1,32 +1,33 @@
 # GObject must be imported first so the overrides can be imported
-from gi.repository import GObject
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Concatenate,
+    Generator,
+    Generic,
+    Literal,
+    Optional,
+    ParamSpec,
+    Self,
+    TypeVar,
+    Union,
+    overload,
+)
+
+import gi._propertyhelper
+import gi._signalhelper
 
 # all aboard...
 import gi.overrides
-import gi._signalhelper
-import gi._propertyhelper
 import gi.overrides.GObject
+from gi.repository import GObject
 
-from dataclasses import dataclass
-from collections.abc import Callable
-from typing import (
-    overload,
-    Concatenate,
-    ParamSpec,
-    Generator,
-    Optional,
-    Generic,
-    TypeVar,
-    Literal,
-    Union,
-    Self,
-    Any,
-)
 from fabric.utils.helpers import (
     get_enum_member,
-    snake_case_to_kebab_case,
-    kebab_case_to_snake_case,
     get_function_annotations,
+    kebab_case_to_snake_case,
+    snake_case_to_kebab_case,
 )
 
 OldSignal = gi._signalhelper.Signal
@@ -116,9 +117,13 @@ class Property(OldProperty, Generic[T]):
                 "_setter_middle_gate",
                 lambda instance, value: self.fset(instance, value),  # type: ignore
             )
+        try:
+            _type = type if issubclass(type, (bool, int, float, str)) else object
+        except TypeError:
+            _type = object
 
         super().__init__(
-            type=type if issubclass(type, (bool, int, float, str)) else object,
+            type=_type,
             default=default_value,
             nick=nickname or "",
             blurb=description,
@@ -432,8 +437,10 @@ class Service(OldGObject, Generic[P, T]):
         target_object: GObject.Object,
         transform_to: Callable[[GObject.Binding, Any], Any] | None = None,
         transform_from: Callable[[GObject.Binding, Any], Any] | None = None,
-        flags: Literal["default", "bidirectional", "sync-create", "invert-boolean"]
-        | GObject.BindingFlags = GObject.BindingFlags.DEFAULT,
+        flags: (
+            Literal["default", "bidirectional", "sync-create", "invert-boolean"]
+            | GObject.BindingFlags
+        ) = GObject.BindingFlags.DEFAULT,
     ):
         return self.bind_property(
             source_property,

--- a/fabric/widgets/circularprogressbar.py
+++ b/fabric/widgets/circularprogressbar.py
@@ -3,13 +3,13 @@ from typing import Iterable, Literal
 
 import cairo
 import gi
+from gi.repository import Gdk, Gtk
 
 from fabric.core.service import Property
 from fabric.utils.helpers import clamp, get_enum_member
 from fabric.widgets.widget import Widget
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gdk, Gtk
 
 
 class CircularProgressBar(Gtk.Bin, Widget):


### PR DESCRIPTION
Adds missing (probably needed in some setups) features to the `CircularProgressBar` widget, those are...
- `start_angle` and `end_angle`
- The ability to add a child (via the `child` property)