### PR TITLE
fix: handle empty title in tooltip markup

### DIFF
--- a/fabric/system_tray/widgets.py
+++ b/fabric/system_tray/widgets.py
@@ -30,7 +30,7 @@ class SystemTrayItem(Button):
 
         tooltip = self._item.tooltip
         self.set_tooltip_markup(
-            tooltip.description or tooltip.title or self._item.title.title()
+            tooltip.description or tooltip.title or self._item.title.title() if self._item.title else ""
         )
         return
 


### PR DESCRIPTION
This PR fixes a bug where the SystemTrayItem would crash if the item title was missing. The updated code makes sure that the tooltip gets set to "" if it's not available.