### PR TITLE
fix: prevent tooltip markup from processing when title is None

### DIFF
--- a/fabric/system_tray/widgets.py
+++ b/fabric/system_tray/widgets.py
@@ -30,7 +30,7 @@ class SystemTrayItem(Button):
 
         tooltip = self._item.tooltip
         self.set_tooltip_markup(
-            tooltip.description or tooltip.title or self._item.title.title()
+            tooltip.description or tooltip.title or self._item.title.title() if self._item.title else ""
         )
         return
 

--- a/fabric/system_tray/widgets.py
+++ b/fabric/system_tray/widgets.py
@@ -29,10 +29,8 @@ class SystemTrayItem(Button):
             self._image.set_from_icon_name("image-missing", self._icon_size)
 
         tooltip = self._item.tooltip
-        if self._item.title is None:
-            return
         self.set_tooltip_markup(
-            tooltip.description or tooltip.title or self._item.title.title()
+            tooltip.description or tooltip.title or self._item.title.title() if self._item.title else "Unknown"
         )
         return
 

--- a/fabric/system_tray/widgets.py
+++ b/fabric/system_tray/widgets.py
@@ -29,8 +29,10 @@ class SystemTrayItem(Button):
             self._image.set_from_icon_name("image-missing", self._icon_size)
 
         tooltip = self._item.tooltip
+        if self._item.title is None:
+            return
         self.set_tooltip_markup(
-            tooltip.description or tooltip.title or self._item.title.title() if self._item.title else ""
+            tooltip.description or tooltip.title or self._item.title.title()
         )
         return
 


### PR DESCRIPTION
This PR fixes a bug where the SystemTrayItem would crash if the item title was missing. The updated code makes sure that the tooltip gets set to None if it's not available.