### PR TITLE
fix: set max value first on scale to satisfy range assertion

### DIFF
--- a/fabric/widgets/scale.py
+++ b/fabric/widgets/scale.py
@@ -109,8 +109,9 @@ class Scale(Gtk.Scale, Widget):
         self._min_value: float = 0
         self._max_value: float = 1.0
 
-        self.min_value = min_value
         self.max_value = max_value
+        self.min_value = min_value
+
         self.value = value
 
         self.set_orientation(


### PR DESCRIPTION
if i supply min value = 1000 , the default max value is used i.e 1.0 until the  ` self.max_value = max_value` is touched which updates the max value. Thus the assertion fails as we are using set_range on  self.min_value setter function  i.e max > min

![image](https://github.com/user-attachments/assets/66cba5ed-ff7f-40e0-a208-81111549b4d6)
