### PR TITLE
fix(notifications): correct image deserialization type error

### DIFF
--- a/fabric/notifications/service.py
+++ b/fabric/notifications/service.py
@@ -55,7 +55,9 @@ class NotificationImagePixmap:
 
         # if this doesn't work, please report.
         loader = GdkPixbuf.PixbufLoader.new_with_type("png")
-        loader.write_bytes(base64.b64decode(pixmap_data))  # type: ignore
+        decoded_data = base64.b64decode(pixmap_data)
+        bytes_data = GLib.Bytes.new(decoded_data)
+        loader.write_bytes(bytes_data)  # type: ignore
         loader.close()
 
         self._pixbuf = loader.get_pixbuf()  # type: ignore


### PR DESCRIPTION
Fixed TypeError when deserializing cached notifications by properly wrapping decoded image data in GLib.Bytes before passing to PixbufLoader.

Previously, base64 decoded bytes were passed directly to write_bytes() which expects GLib.Bytes. Now we correctly create GLib.Bytes from the decoded data.

This resolves the crash during notification cache loading when images are present.