### PR TITLE
feat(nix): reintroduce flake implementation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .vscode
 *vscode*
 
+# nix
+.direnv/
+result
+
 # ruff formatter
 .ruff*/
 

--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,49 @@
 {
   lib,
-  python312Packages,
+  pkg-config,
+  wrapGAppsHook3,
+  gobject-introspection,
+  python3,
+  python3Packages,
+  runtimeShell,
   gtk3,
   gtk-layer-shell,
   cairo,
-  gobject-introspection,
   libdbusmenu-gtk3,
   gdk-pixbuf,
   cinnamon-desktop,
   gnome-bluetooth,
+  extraPackages ? [ ],
+  extraDependencies ? [ ],
 }:
-python312Packages.buildPythonPackage {
+let
+  pydeps =
+    ps:
+    with ps;
+    [
+      click
+      pycairo
+      pygobject3
+      pygobject-stubs
+      loguru
+      psutil
+    ]
+    ++ extraDependencies;
+in
+python3Packages.buildPythonPackage {
   pname = "python-fabric";
   version = "0.0.2";
   pyproject = true;
 
   src = ./.;
+
+  build-system = [ python3Packages.setuptools ];
+
+  nativeBuildInputs = [
+    pkg-config
+    gobject-introspection
+    wrapGAppsHook3
+  ];
 
   buildInputs = [
     gtk3
@@ -26,25 +54,31 @@ python312Packages.buildPythonPackage {
     gdk-pixbuf
     cinnamon-desktop
     gnome-bluetooth
-  ];
+  ] ++ extraPackages;
 
-  dependencies = with python312Packages; [
-    setuptools
-    click
-    pycairo
-    pygobject3
-    pygobject-stubs
-    loguru
-    psutil
-  ];
+  dependencies = pydeps python3Packages;
+
+  postInstall =
+    let
+      py = python3.withPackages pydeps;
+    in
+    ''
+      mkdir -p $out/bin
+      cat > $out/bin/fabric << EOF
+      #!${runtimeShell}
+      export PYTHONPATH="${toString ./.}:${py}/lib/python${py.python.version}/site-packages"
+      GI_TYPELIB_PATH=$GI_TYPELIB_PATH \
+      GDK_PIXBUF_MODULE_FILE="$GDK_PIXBUF_MODULE_FILE" \
+      ${py.interpreter} -m fabric "\$@"
+      EOF
+      chmod +x $out/bin/fabric
+    '';
 
   meta = {
-    changelog = "";
-    description = ''
-      next-gen framework for building desktop widgets using Python (check the rewrite branch for progress)
-    '';
+    changelog = "https://github.com/Fabric-Development/fabric/blob/master/CHANGELOG.md";
+    description = "The next-generation framework for building desktop widgets using Python";
     homepage = "https://github.com/Fabric-Development/fabric";
     license = lib.licenses.agpl3Plus;
-    maintainers = with lib.maintainers; [];
+    maintainers = with lib.maintainers; [ ];
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,57 +2,23 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733261153,
-        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
+        "lastModified": 1751382304,
+        "narHash": "sha256-p+UruOjULI5lV16FkBqkzqgFasLqfx0bihLBeFHiZAs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
+        "rev": "d31a91c9b3bee464d054633d5f8b84e17a637862",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,71 +1,55 @@
 {
-  description = ''
-    next-gen framework for building desktop widgets using Python
-    (check the rewrite branch for progress)
-  '';
+  description = "The next-generation framework for building desktop widgets using Python";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-    utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = {
-    nixpkgs,
-    utils,
-    ...
-  }:
-    utils.lib.eachDefaultSystem (
-      system: let
-        overlay = final: prev: {
-          pythonPackagesExtensions =
-            prev.pythonPackagesExtensions
-            ++ [
-              (python-final: python-prev: {
-                python-fabric = prev.callPackage ./default.nix {};
-              })
-            ];
-        };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      systems = lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
 
-        pkgs = nixpkgs.legacyPackages.${system}.extend overlay;
-      in {
-        overlays.default = overlay;
-        formatter = pkgs.nixfmt-rfc-style;
-        packages = {
-          default = pkgs.python3Packages.python-fabric;
-          run-widget = pkgs.callPackage ./run-widget.nix {};
-        };
+      packages = forAllSystems (pkgs: rec {
+        default = pkgs.callPackage ./default.nix { };
+        python-fabric = default;
+        run-widget =
+          lib.warn
+            "`run-widget` is deprecated and is going to be removed in future releases of fabric. refer to the wiki for more information."
+            pkgs.callPackage
+            ./run-widget.nix
+            { inherit python-fabric; };
+      });
 
-        devShells = {
+      devShells = forAllSystems (
+        pkgs:
+        let
+          inherit (self.packages.${pkgs.system}) python-fabric;
+        in
+        {
           default = pkgs.mkShell {
             name = "fabric-shell";
-            packages = with pkgs; [
-              ruff
-              gtk3
-              gtk-layer-shell
-              cairo
-              gobject-introspection
-              libdbusmenu-gtk3
-              gdk-pixbuf
-              gnome-bluetooth
-              cinnamon-desktop
-              (python3.withPackages (
-                ps:
-                  with ps; [
-                    setuptools
-                    wheel
-                    build
-                    click
-                    pycairo
-                    pygobject3
-                    pygobject-stubs
-                    loguru
-                    psutil
-                    python-fabric
-                  ]
-              ))
+            inputsFrom = [ python-fabric ];
+            packages = [
+              python-fabric
+              pkgs.ruff
             ];
           };
-        };
-      }
-    );
+        }
+      );
+
+      overlays.default = final: prev: { inherit (self.packages.${prev.system}) python-fabric; };
+    };
 }

--- a/run-widget.nix
+++ b/run-widget.nix
@@ -10,49 +10,49 @@
   gnome-bluetooth,
   cinnamon-desktop,
   librsvg,
-  extraPythonPackages ? [],
-  extraBuildInputs ? [],
-}: let
+  python-fabric,
+  extraPythonPackages ? [ ],
+  extraBuildInputs ? [ ],
+}:
+let
   python = python3.withPackages (
     ps:
-      with ps;
-        [
-          click
-          pycairo
-          pygobject3
-          loguru
-          psutil
-          python-fabric
-          pygobject-stubs
-        ]
-        ++ extraPythonPackages
+    with ps;
+    [
+      click
+      pycairo
+      pygobject3
+      loguru
+      psutil
+      pygobject-stubs
+    ]
+    ++ [ python-fabric ]
+    ++ extraPythonPackages
   );
 in
-  stdenv.mkDerivation {
-    name = "run-widget";
-    propagatedBuildInputs =
-      [
-        gtk3
-        gtk-layer-shell
-        cairo
-        gobject-introspection
-        libdbusmenu-gtk3
-        gdk-pixbuf
-        librsvg
-        gnome-bluetooth
-        cinnamon-desktop
-      ]
-      ++ extraBuildInputs;
-    phases = ["installPhase"];
-    installPhase = ''
-      mkdir -p $out/bin
-      cat > $out/bin/run-widget << EOF
-      #!/bin/sh
-      GI_TYPELIB_PATH=$GI_TYPELIB_PATH \
-      GDK_PIXBUF_MODULE_FILE="$GDK_PIXBUF_MODULE_FILE" \
-      ${python.interpreter} "\$@"
-      EOF
-      chmod +x $out/bin/run-widget
-    '';
-    meta.mainProgram = "run-widget";
-  }
+stdenv.mkDerivation {
+  name = "run-widget";
+  propagatedBuildInputs = [
+    gtk3
+    gtk-layer-shell
+    cairo
+    gobject-introspection
+    libdbusmenu-gtk3
+    gdk-pixbuf
+    librsvg
+    gnome-bluetooth
+    cinnamon-desktop
+  ] ++ extraBuildInputs;
+  phases = [ "installPhase" ];
+  installPhase = ''
+    mkdir -p $out/bin
+    cat > $out/bin/run-widget << EOF
+    #!/bin/sh
+    GI_TYPELIB_PATH=$GI_TYPELIB_PATH \
+    GDK_PIXBUF_MODULE_FILE="$GDK_PIXBUF_MODULE_FILE" \
+    ${python.interpreter} "\$@"
+    EOF
+    chmod +x $out/bin/run-widget
+  '';
+  meta.mainProgram = "run-widget";
+}


### PR DESCRIPTION
- I reworked the flake because it was unnecessarily complex.
- The package is now built with Python 3.13 since that is the default in nixpkgs.
- Removed the `run-widget` since that can be done directly via the main package.

This introduces breaking change for people who relied on `run-widget`.

I would be happy to open a PR to document the installation method for Nix users, if this one goes through.