### PR TITLE
feat: separate window manager specific widgets into abstractions 

### DIFF
--- a/examples/bar/config.py
+++ b/examples/bar/config.py
@@ -8,7 +8,12 @@ from fabric.widgets.centerbox import CenterBox
 from fabric.system_tray.widgets import SystemTray
 from fabric.widgets.circularprogressbar import CircularProgressBar
 from fabric.widgets.wayland import WaylandWindow as Window
-from fabric.hyprland.widgets import Language, ActiveWindow, Workspaces, WorkspaceButton
+from fabric.hyprland.widgets import (
+    HyprlandLanguage,
+    HyprlandActiveWindow,
+    HyprlandWorkspaces,
+    WorkspaceButton,
+)
 from fabric.utils import FormattedString, get_relative_path, bulk_replace
 
 AUDIO_WIDGET = True
@@ -108,7 +113,7 @@ class StatusBar(Window):
             name="bar-inner",
             start_children=Box(
                 name="start-container",
-                children=Workspaces(
+                children=HyprlandWorkspaces(
                     name="workspaces",
                     spacing=4,
                     buttons_factory=lambda ws_id: WorkspaceButton(id=ws_id, label=None),
@@ -116,7 +121,7 @@ class StatusBar(Window):
             ),
             center_children=Box(
                 name="center-container",
-                children=ActiveWindow(name="hyprland-window"),
+                children=HyprlandActiveWindow(name="hyprland-window"),
             ),
             end_children=Box(
                 name="end-container",
@@ -126,7 +131,7 @@ class StatusBar(Window):
                     self.system_status,
                     SystemTray(name="system-tray", spacing=4),
                     DateTime(name="date-time"),
-                    Language(
+                    HyprlandLanguage(
                         name="hyprland-window",
                         formatter=FormattedString(
                             "{replace_lang(language)}",

--- a/fabric/core/widgets/__init__.py
+++ b/fabric/core/widgets/__init__.py
@@ -1,0 +1,3 @@
+from .wm import WorkspaceButton, Workspaces, ActiveWindow, Language
+
+__all__ = ["WorkspaceButton", "Workspaces", "ActiveWindow", "Language"]

--- a/fabric/core/widgets/wm.py
+++ b/fabric/core/widgets/wm.py
@@ -1,0 +1,287 @@
+import gi
+import re
+from loguru import logger
+from typing import Literal
+from collections.abc import Iterable, Callable
+from fabric.core.service import Signal, Property
+from fabric.widgets.box import Box
+from fabric.widgets.button import Button
+from fabric.widgets.eventbox import EventBox
+from fabric.utils.helpers import FormattedString, truncate
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
+
+
+class WorkspaceButton(Button):
+    @Property(int, "readable")
+    def id(self) -> int:
+        return self._id
+
+    @Property(bool, "read-write", default_value=False)
+    def active(self) -> bool:
+        return self._active
+
+    @active.setter
+    def active(self, value: bool):
+        self._active = value
+        if value is True:
+            self.urgent = False
+        (self.remove_style_class if not value else self.add_style_class)("active")
+        return self.do_bake_label()
+
+    @Property(bool, "read-write", default_value=False)
+    def urgent(self) -> bool:
+        return self._urgent
+
+    @urgent.setter
+    def urgent(self, value: bool):
+        self._urgent = value
+        (self.remove_style_class if not value else self.add_style_class)("urgent")
+        return self.do_bake_label()
+
+    @Property(bool, "read-write", default_value=True)
+    def empty(self) -> bool:
+        return self._empty
+
+    @empty.setter
+    def empty(self, value: bool):
+        self._empty = value
+        (self.remove_style_class if not value else self.add_style_class)("empty")
+        return self.do_bake_label()
+
+    def __init__(
+        self,
+        id: int,
+        label: FormattedString | str | None = None,
+        image: Gtk.Image | None = None,
+        child: Gtk.Widget | None = None,
+        name: str | None = None,
+        visible: bool = True,
+        all_visible: bool = False,
+        style: str | None = None,
+        style_classes: Iterable[str] | str | None = None,
+        tooltip_text: str | None = None,
+        tooltip_markup: str | None = None,
+        h_align: Literal["fill", "start", "end", "center", "baseline"]
+        | Gtk.Align
+        | None = None,
+        v_align: Literal["fill", "start", "end", "center", "baseline"]
+        | Gtk.Align
+        | None = None,
+        h_expand: bool = False,
+        v_expand: bool = False,
+        size: Iterable[int] | int | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            None,
+            image,
+            child,
+            name,
+            visible,
+            all_visible,
+            style,
+            style_classes,
+            tooltip_text,
+            tooltip_markup,
+            h_align,
+            v_align,
+            h_expand,
+            v_expand,
+            size,
+            **kwargs,
+        )
+        self._id: int = id
+        self._label: FormattedString | None = (
+            FormattedString(label) if isinstance(label, str) else label
+        )
+        self._active: bool = False
+        self._urgent: bool = False
+        self._empty: bool = True
+
+        self.active = False
+        self.urgent = False
+        self.empty = True
+
+    def do_bake_label(self):
+        if not self._label:
+            return
+        return self.set_label(self._label.format(button=self))
+
+
+class Workspaces(EventBox):
+    @staticmethod
+    def default_buttons_factory(workspace_id: int):
+        return WorkspaceButton(id=workspace_id, label=str(workspace_id))
+
+    @Signal
+    def workspace_activated(self, workspace_id: int):
+        if workspace_id == self._active_workspace:
+            return
+
+        if self._active_workspace is not None and (
+            old_btn := self._buttons.get(self._active_workspace)
+        ):
+            old_btn.active = False
+
+        self._active_workspace = workspace_id
+        if not (btn := self.lookup_or_bake_button(workspace_id)):
+            return
+
+        btn.urgent = False
+        btn.active = True
+
+        if btn in self._container.children:
+            return
+        return self.insert_button(btn)
+
+    @Signal
+    def workspace_created(self, workspace_id: int):
+        if not (btn := self.lookup_or_bake_button(workspace_id)):
+            return
+
+        btn.empty = False
+        if btn in self._buttons_preset:
+            return
+        return self.insert_button(btn)
+
+    @Signal
+    def workspace_destroyed(self, workspace_id: int):
+        if not (btn := self._buttons.get(workspace_id)):
+            return  # doesn't exist, skip
+
+        btn.active = False
+        btn.urgent = False
+        btn.empty = True
+
+        if btn in self._buttons_preset:
+            return
+        return self.remove_button(btn)
+
+    @Signal
+    def urgent(self, workspace_id: int):
+        if not (btn := self._buttons.get(workspace_id)):
+            return  # doesn't exist, skip
+
+        btn.urgent = True
+        return logger.info(f"[Workspaces] workspace {workspace_id} is now urgent")
+
+    # user interaction (e.g. scrolling)
+    @Signal
+    def action_next(self): ...
+
+    @Signal
+    def action_previous(self): ...
+
+    @Signal
+    def button_clicked(self, button: WorkspaceButton): ...
+
+    def __init__(
+        self,
+        buttons: Iterable[WorkspaceButton] | None = None,
+        buttons_factory: Callable[[int], WorkspaceButton | None]
+        | None = default_buttons_factory,
+        invert_scroll: bool = False,
+        **kwargs,
+    ):
+        super().__init__(events="scroll")
+
+        self._container = Box(**kwargs)
+
+        self.children = self._container
+
+        self._active_workspace: int | None = None
+        self._buttons: dict[int, WorkspaceButton] = {}
+        self._buttons_preset: list[WorkspaceButton] = [
+            button for button in buttons or ()
+        ]
+        self._buttons_factory = buttons_factory
+        self._invert_scroll = invert_scroll
+
+        for btn in self._buttons_preset:
+            self.insert_button(btn)
+
+    def do_handle_scroll(self, _, event: Gdk.EventScroll):  # TODO: abstract
+        match event.direction:  # type: ignore
+            case Gdk.ScrollDirection.UP:
+                self.action_next() if not self._invert_scroll else self.action_previous()
+                logger.info("[Workspaces] Moving to the next workspace")
+            case Gdk.ScrollDirection.DOWN:
+                self.action_previous() if not self._invert_scroll else self.action_next()
+                logger.info("[Workspaces] Moving to the previous workspace")
+            case _:
+                return logger.warning(
+                    f"[Workspaces] Unknown scroll direction ({event.direction})"  # type: ignore
+                )
+        return
+
+    def insert_button(self, button: WorkspaceButton) -> None:
+        self._buttons[button.id] = button
+        self._container.add(button)
+        button.connect("clicked", self.do_handle_button_press)
+        return self.reorder_buttons()
+
+    def reorder_buttons(self):
+        for _, child in sorted(self._buttons.items(), key=lambda i: i[0]):
+            self._container.reorder_child(child, (child.id - 1))
+        return
+
+    def remove_button(self, button: WorkspaceButton) -> None:
+        if self._buttons.pop(button.id, None) is not None:
+            self._container.remove(button)
+        return button.destroy()
+
+    def lookup_or_bake_button(self, workspace_id: int) -> WorkspaceButton | None:
+        if not (btn := self._buttons.get(workspace_id)) and self._buttons_factory:
+            btn = self._buttons_factory(workspace_id)
+        return btn
+
+    def do_handle_button_press(self, button: WorkspaceButton):  # TODO: abstract
+        self.button_clicked(button)
+        return logger.info(f"[Workspaces] Moved to workspace {button.id}")
+
+
+class ActiveWindow(Button):
+    @Signal
+    def window_activated(self, window_class: str, window_title: str):
+        return self.set_label(
+            self.formatter.format(win_class=window_class, win_title=window_title)
+        )
+
+    def __init__(
+        self,
+        formatter: FormattedString = FormattedString(
+            "{'Desktop' if not win_title else truncate(win_title, 42)}",
+            truncate=truncate,
+        ),
+        # TODO: hint super's kwargs
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.formatter = formatter
+
+
+class Language(Button):
+    @Signal
+    def layout_changed(self, language: str, keyboard: str) -> bool:
+        matched: bool = False
+
+        if re.match(self.keyboard, keyboard) and (matched := True):
+            self.set_label(self.formatter.format(language=language))
+
+        logger.debug(
+            f"[Language] Keyboard: {keyboard}, Language: {language}, Match: {matched}"
+        )
+        return matched
+
+    def __init__(
+        self,
+        keyboard: str = ".*",
+        formatter: FormattedString = FormattedString("{language}"),
+        # TODO: hint super's kwargs
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.keyboard = keyboard
+        self.formatter = formatter

--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -1,18 +1,10 @@
-import gi
-import re
 import json
 from loguru import logger
-from typing import Literal
 from collections.abc import Iterable, Callable
-from fabric.core.service import Signal, Property
-from fabric.widgets.box import Box
-from fabric.widgets.button import Button
-from fabric.widgets.eventbox import EventBox
-from fabric.hyprland.service import Hyprland, HyprlandEvent
-from fabric.utils.helpers import FormattedString, bulk_connect, truncate
 
-gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk, Gdk
+from fabric.hyprland.service import Hyprland, HyprlandEvent
+from fabric.core.widgets import WorkspaceButton, Workspaces, ActiveWindow, Language
+from fabric.utils.helpers import FormattedString, bulk_connect, truncate
 
 
 connection: Hyprland | None = None
@@ -26,196 +18,20 @@ def get_hyprland_connection() -> Hyprland:
     return connection
 
 
-class WorkspaceButton(Button):
-    @Property(int, "readable")
-    def id(self) -> int:
-        return self._id
-
-    @Property(bool, "read-write", default_value=False)
-    def active(self) -> bool:
-        return self._active
-
-    @active.setter
-    def active(self, value: bool):
-        self._active = value
-        if value is True:
-            self.urgent = False
-        (self.remove_style_class if not value else self.add_style_class)("active")
-        return self.do_bake_label()
-
-    @Property(bool, "read-write", default_value=False)
-    def urgent(self) -> bool:
-        return self._urgent
-
-    @urgent.setter
-    def urgent(self, value: bool):
-        self._urgent = value
-        (self.remove_style_class if not value else self.add_style_class)("urgent")
-        return self.do_bake_label()
-
-    @Property(bool, "read-write", default_value=True)
-    def empty(self) -> bool:
-        return self._empty
-
-    @empty.setter
-    def empty(self, value: bool):
-        self._empty = value
-        (self.remove_style_class if not value else self.add_style_class)("empty")
-        return self.do_bake_label()
-
-    def __init__(
-        self,
-        id: int,
-        label: FormattedString | str | None = None,
-        image: Gtk.Image | None = None,
-        child: Gtk.Widget | None = None,
-        name: str | None = None,
-        visible: bool = True,
-        all_visible: bool = False,
-        style: str | None = None,
-        style_classes: Iterable[str] | str | None = None,
-        tooltip_text: str | None = None,
-        tooltip_markup: str | None = None,
-        h_align: Literal["fill", "start", "end", "center", "baseline"]
-        | Gtk.Align
-        | None = None,
-        v_align: Literal["fill", "start", "end", "center", "baseline"]
-        | Gtk.Align
-        | None = None,
-        h_expand: bool = False,
-        v_expand: bool = False,
-        size: Iterable[int] | int | None = None,
-        **kwargs,
-    ):
-        super().__init__(
-            None,
-            image,
-            child,
-            name,
-            visible,
-            all_visible,
-            style,
-            style_classes,
-            tooltip_text,
-            tooltip_markup,
-            h_align,
-            v_align,
-            h_expand,
-            v_expand,
-            size,
-            **kwargs,
-        )
-        self._id: int = id
-        self._label: FormattedString | None = (
-            FormattedString(label) if isinstance(label, str) else label
-        )
-        self._active: bool = False
-        self._urgent: bool = False
-        self._empty: bool = True
-
-        self.active = False
-        self.urgent = False
-        self.empty = True
-
-    def do_bake_label(self):
-        if not self._label:
-            return
-        return self.set_label(self._label.format(button=self))
-
-
-class Workspaces(EventBox):
-    @staticmethod
-    def default_buttons_factory(workspace_id: int):
-        return WorkspaceButton(id=workspace_id, label=str(workspace_id))
-
-    @Signal
-    def workspace_activated(self, workspace_id: int):
-        if workspace_id == self._active_workspace:
-            return
-
-        if self._active_workspace is not None and (
-            old_btn := self._buttons.get(self._active_workspace)
-        ):
-            old_btn.active = False
-
-        self._active_workspace = workspace_id
-        if not (btn := self.lookup_or_bake_button(workspace_id)):
-            return
-
-        btn.urgent = False
-        btn.active = True
-
-        if btn in self._container.children:
-            return
-        return self.insert_button(btn)
-
-    @Signal
-    def workspace_created(self, workspace_id: int):
-        if not (btn := self.lookup_or_bake_button(workspace_id)):
-            return
-
-        btn.empty = False
-        if btn in self._buttons_preset:
-            return
-        return self.insert_button(btn)
-
-    @Signal
-    def workspace_destroyed(self, workspace_id: int):
-        if not (btn := self._buttons.get(workspace_id)):
-            return  # doesn't exist, skip
-
-        btn.active = False
-        btn.urgent = False
-        btn.empty = True
-
-        if btn in self._buttons_preset:
-            return
-        return self.remove_button(btn)
-
-    @Signal
-    def urgent(self, workspace_id: int):
-        if not (btn := self._buttons.get(workspace_id)):
-            return  # doesn't exist, skip
-
-        btn.urgent = True
-        return logger.info(f"[Workspaces] workspace {workspace_id} is now urgent")
-
-    # user interaction (e.g. scrolling)
-    @Signal
-    def action_next(self): ...
-
-    @Signal
-    def action_previous(self): ...
-
-    @Signal
-    def button_clicked(self, button: WorkspaceButton): ...
-
+class HyprlandWorkspaces(Workspaces):
     def __init__(
         self,
         buttons: Iterable[WorkspaceButton] | None = None,
         buttons_factory: Callable[[int], WorkspaceButton | None]
-        | None = default_buttons_factory,
+        | None = Workspaces.default_buttons_factory,
         invert_scroll: bool = False,
         empty_scroll: bool = False,
         **kwargs,
     ):
-        super().__init__(events="scroll")
+        super().__init__(buttons, buttons_factory, invert_scroll, **kwargs)
         self.connection = get_hyprland_connection()
-        self._container = Box(**kwargs)
-        self.children = self._container
 
-        self._active_workspace: int | None = None
-        self._buttons: dict[int, WorkspaceButton] = {}
-        self._buttons_preset: list[WorkspaceButton] = [
-            button for button in buttons or ()
-        ]
-        self._buttons_factory = buttons_factory
-        self._invert_scroll = invert_scroll
         self._empty_scroll = empty_scroll
-
-        for btn in self._buttons_preset:
-            self.insert_button(btn)
-
         bulk_connect(
             self.connection,
             {
@@ -229,12 +45,12 @@ class Workspaces(EventBox):
 
         # all aboard...
         if self.connection.ready:
-            self.on_ready(None)
+            self.on_ready()
         else:
             self.connection.connect("event::ready", self.on_ready)
         self.connect("scroll-event", self.do_handle_scroll)
 
-    def on_ready(self, _):
+    def on_ready(self):
         open_workspaces: tuple[int, ...] = tuple(
             workspace["id"]
             for workspace in json.loads(
@@ -284,63 +100,21 @@ class Workspaces(EventBox):
             )
         return self.workspace_destroyed(int(raw_workspace["id"]))
 
-    def do_handle_scroll(self, _, event: Gdk.EventScroll):  # TODO: abstract
-        match event.direction:  # type: ignore
-            case Gdk.ScrollDirection.UP:
-                self.action_next() if not self._invert_scroll else self.action_previous()
-                logger.info("[Workspaces] Moving to the next workspace")
-            case Gdk.ScrollDirection.DOWN:
-                self.action_previous() if not self._invert_scroll else self.action_next()
-                logger.info("[Workspaces] Moving to the previous workspace")
-            case _:
-                return logger.warning(
-                    f"[Workspaces] Unknown scroll direction ({event.direction})"  # type: ignore
-                )
-        return
-
-    def insert_button(self, button: WorkspaceButton) -> None:
-        self._buttons[button.id] = button
-        self._container.add(button)
-        button.connect("clicked", self.do_handle_button_press)
-        return self.reorder_buttons()
-
-    def reorder_buttons(self):
-        for _, child in sorted(self._buttons.items(), key=lambda i: i[0]):
-            self._container.reorder_child(child, (child.id - 1))
-        return
-
-    def remove_button(self, button: WorkspaceButton) -> None:
-        if self._buttons.pop(button.id, None) is not None:
-            self._container.remove(button)
-        return button.destroy()
-
-    def lookup_or_bake_button(self, workspace_id: int) -> WorkspaceButton | None:
-        if not (btn := self._buttons.get(workspace_id)) and self._buttons_factory:
-            btn = self._buttons_factory(workspace_id)
-        return btn
-
-    def do_handle_button_press(self, button: WorkspaceButton):  # TODO: abstract
-        self.button_clicked(button)
-        return logger.info(f"[Workspaces] Moved to workspace {button.id}")
-
-    # TODO: be a part of the hyprland widget implementation
     def do_action_next(self):
-        return self.connection.send_command("batch/dispatch workspace e+1")
+        return self.connection.send_command(
+            f"batch/dispatch workspace {'e' if not self._empty_scroll else ''}+1"
+        )
 
     def do_action_previous(self):
-        return self.connection.send_command("batch/dispatch workspace e-1")
+        return self.connection.send_command(
+            f"batch/dispatch workspace {'e' if not self._empty_scroll else ''}-1"
+        )
 
     def do_button_clicked(self, button: WorkspaceButton):
         return self.connection.send_command(f"batch/dispatch workspace {button.id}")
 
 
-class ActiveWindow(Button):
-    @Signal
-    def window_activated(self, window_class: str, window_title: str):
-        return self.set_label(
-            self.formatter.format(win_class=window_class, win_title=window_title)
-        )
-
+class HyprlandActiveWindow(ActiveWindow):
     def __init__(
         self,
         formatter: FormattedString = FormattedString(
@@ -350,10 +124,8 @@ class ActiveWindow(Button):
         # TODO: hint super's kwargs
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.formatter = formatter
+        super().__init__(formatter, **kwargs)
 
-        # window manager specific
         self.connection = get_hyprland_connection()
         bulk_connect(
             self.connection,
@@ -365,11 +137,11 @@ class ActiveWindow(Button):
 
         # all aboard...
         if self.connection.ready:
-            self.on_ready(None)
+            self.on_ready()
         else:
             self.connection.connect("event::ready", self.on_ready)
 
-    def on_ready(self, _):
+    def on_ready(self):
         return self.do_initialize(), logger.info(
             "[ActiveWindow] Connected to the hyprland socket"
         )
@@ -398,19 +170,7 @@ class ActiveWindow(Button):
         return self.window_activated(win_class, win_title)
 
 
-class Language(Button):
-    @Signal
-    def layout_changed(self, language: str, keyboard: str) -> bool:
-        matched: bool = False
-
-        if re.match(self.keyboard, keyboard) and (matched := True):
-            self.set_label(self.formatter.format(language=language))
-
-        logger.debug(
-            f"[Language] Keyboard: {keyboard}, Language: {language}, Match: {matched}"
-        )
-        return matched
-
+class HyprlandLanguage(Language):
     def __init__(
         self,
         keyboard: str = ".*",
@@ -418,21 +178,18 @@ class Language(Button):
         # TODO: hint super's kwargs
         **kwargs,
     ):
-        super().__init__(**kwargs)
-        self.keyboard = keyboard
-        self.formatter = formatter
+        super().__init__(keyboard, formatter, **kwargs)
 
-        # window manager specific
         self.connection = get_hyprland_connection()
         self.connection.connect("event::activelayout", self.on_activelayout)
 
         # all aboard...
         if self.connection.ready:
-            self.on_ready(None)
+            self.on_ready()
         else:
             self.connection.connect("event::ready", self.on_ready)
 
-    def on_ready(self, _):
+    def on_ready(self):
         return self.do_initialize(), logger.info(
             "[Language] Connected to the hyprland socket"
         )
@@ -443,14 +200,8 @@ class Language(Button):
                 f"[Language] got invalid event data from hyprland, raw data is\n{event.raw_data}"
             )
         keyboard, language = event.data
-        matched: bool = False
 
-        if re.match(self.keyboard, keyboard) and (matched := True):
-            self.set_label(self.formatter.format(language=language))
-
-        return logger.debug(
-            f"[Language] Keyboard: {keyboard}, Language: {language}, Match: {matched}"
-        )
+        return self.layout_changed(language, keyboard)
 
     def do_initialize(self):
         devices: dict[str, list[dict[str, str]]] = json.loads(
@@ -484,3 +235,12 @@ class Language(Button):
                 f"[Language] Set language: {language} for keyboard: {self.keyboard}"
             )
         )
+
+
+__all__ = [
+    "HyprlandWorkspaces",
+    "HyprlandActiveWindow",
+    "HyprlandLanguage",
+    "WorkspaceButton",
+    "get_hyprland_connection",
+]

--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -36,9 +36,9 @@ class HyprlandWorkspaces(Workspaces):
             self.connection,
             {
                 "event::workspacev2": self.on_workspace,
-                "event::focusedmon": self.on_monitor,
-                "event::createworkspacev2": self.on_createworkspace,
-                "event::destroyworkspacev2": self.on_destroyworkspace,
+                "event::focusedmonv2": self.on_monitor,
+                "event::createworkspacev2": self.on_create_workspace,
+                "event::destroyworkspacev2": self.on_destroy_workspace,
                 "event::urgent": self.on_urgent,
             },
         )
@@ -77,12 +77,12 @@ class HyprlandWorkspaces(Workspaces):
             return
         return self.workspace_activated(int(event.data[0]))
 
-    def on_createworkspace(self, _, event: HyprlandEvent):
+    def on_create_workspace(self, _, event: HyprlandEvent):
         if len(event.data) != 2:
             return
         return self.workspace_created(int(event.data[0]))
 
-    def on_destroyworkspace(self, _, event: HyprlandEvent):
+    def on_destroy_workspace(self, _, event: HyprlandEvent):
         if len(event.data) != 2:
             return
         return self.workspace_destroyed(int(event.data[0]))
@@ -130,8 +130,8 @@ class HyprlandActiveWindow(ActiveWindow):
         bulk_connect(
             self.connection,
             {
-                "event::activewindow": self.on_activewindow,
-                "event::closewindow": self.on_closewindow,
+                "event::activewindow": self.on_active_window,
+                "event::closewindow": self.on_close_window,
             },
         )
 
@@ -146,14 +146,14 @@ class HyprlandActiveWindow(ActiveWindow):
             "[ActiveWindow] Connected to the hyprland socket"
         )
 
-    def on_closewindow(self, _, event: HyprlandEvent):
+    def on_close_window(self, _, event: HyprlandEvent):
         if len(event.data) < 1:
             return
         return self.do_initialize(), logger.info(
             f"[ActiveWindow] Closed window 0x{event.data[0]}"
         )
 
-    def on_activewindow(self, _, event: HyprlandEvent):
+    def on_active_window(self, _, event: HyprlandEvent):
         if len(event.data) < 2:
             return
         return self.window_activated(event.data[0], event.data[1]), logger.info(
@@ -181,7 +181,7 @@ class HyprlandLanguage(Language):
         super().__init__(keyboard, formatter, **kwargs)
 
         self.connection = get_hyprland_connection()
-        self.connection.connect("event::activelayout", self.on_activelayout)
+        self.connection.connect("event::activelayout", self.on_active_layout)
 
         # all aboard...
         if self.connection.ready:
@@ -194,7 +194,7 @@ class HyprlandLanguage(Language):
             "[Language] Connected to the hyprland socket"
         )
 
-    def on_activelayout(self, _, event: HyprlandEvent):
+    def on_active_layout(self, _, event: HyprlandEvent):
         if len(event.data) < 2:
             return logger.warning(
                 f"[Language] got invalid event data from hyprland, raw data is\n{event.raw_data}"

--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -199,7 +199,7 @@ class HyprlandLanguage(Language):
             return logger.warning(
                 f"[Language] got invalid event data from hyprland, raw data is\n{event.raw_data}"
             )
-        keyboard, language = event.data
+        keyboard, language, *_ = event.data
 
         return self.layout_changed(language, keyboard)
 

--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -98,7 +98,7 @@ class HyprlandWorkspaces(Workspaces):
             return logger.warning(
                 f"[Workspaces] received urgent signal, but data received ({event.data[0]}) is incorrect, skipping..."
             )
-        return self.workspace_destroyed(int(raw_workspace["id"]))
+        return self.urgent(int(raw_workspace["id"]))
 
     def do_action_next(self):
         return self.connection.send_command(

--- a/fabric/i3/widgets.py
+++ b/fabric/i3/widgets.py
@@ -1,0 +1,467 @@
+import gi
+import re
+import json
+from loguru import logger
+from fabric.core.service import Property
+from collections.abc import Iterable, Callable
+from typing import Literal
+from fabric.widgets.box import Box
+from fabric.widgets.button import Button
+from fabric.widgets.eventbox import EventBox
+from fabric.hyprland.service import Hyprland, HyprlandEvent
+from fabric.utils.helpers import FormattedString, bulk_connect, truncate
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk
+
+
+connection: Hyprland | None = None
+
+
+def get_hyprland_connection() -> Hyprland:
+    global connection
+    if not connection:
+        connection = Hyprland()
+
+    return connection
+
+
+class WorkspaceButton(Button):
+    @Property(int, "readable")
+    def id(self) -> int:
+        return self._id
+
+    @Property(bool, "read-write", default_value=False)
+    def active(self) -> bool:
+        return self._active
+
+    @active.setter
+    def active(self, value: bool):
+        self._active = value
+        if value is True:
+            self.urgent = False
+        (self.remove_style_class if not value else self.add_style_class)("active")
+        return self.do_bake_label()
+
+    @Property(bool, "read-write", default_value=False)
+    def urgent(self) -> bool:
+        return self._urgent
+
+    @urgent.setter
+    def urgent(self, value: bool):
+        self._urgent = value
+        (self.remove_style_class if not value else self.add_style_class)("urgent")
+        return self.do_bake_label()
+
+    @Property(bool, "read-write", default_value=True)
+    def empty(self) -> bool:
+        return self._empty
+
+    @empty.setter
+    def empty(self, value: bool):
+        self._empty = value
+        (self.remove_style_class if not value else self.add_style_class)("empty")
+        return self.do_bake_label()
+
+    def __init__(
+        self,
+        id: int,
+        label: FormattedString | str | None = None,
+        image: Gtk.Image | None = None,
+        child: Gtk.Widget | None = None,
+        name: str | None = None,
+        visible: bool = True,
+        all_visible: bool = False,
+        style: str | None = None,
+        style_classes: Iterable[str] | str | None = None,
+        tooltip_text: str | None = None,
+        tooltip_markup: str | None = None,
+        h_align: Literal["fill", "start", "end", "center", "baseline"]
+        | Gtk.Align
+        | None = None,
+        v_align: Literal["fill", "start", "end", "center", "baseline"]
+        | Gtk.Align
+        | None = None,
+        h_expand: bool = False,
+        v_expand: bool = False,
+        size: Iterable[int] | int | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            None,
+            image,
+            child,
+            name,
+            visible,
+            all_visible,
+            style,
+            style_classes,
+            tooltip_text,
+            tooltip_markup,
+            h_align,
+            v_align,
+            h_expand,
+            v_expand,
+            size,
+            **kwargs,
+        )
+        self._id: int = id
+        self._label: FormattedString | None = (
+            FormattedString(label) if isinstance(label, str) else label
+        )
+        self._active: bool = False
+        self._urgent: bool = False
+        self._empty: bool = True
+
+        self.active = False
+        self.urgent = False
+        self.empty = True
+
+    def do_bake_label(self):
+        if not self._label:
+            return
+        return self.set_label(self._label.format(button=self))
+
+
+class Workspaces(EventBox):
+    @staticmethod
+    def default_buttons_factory(workspace_id: int):
+        return WorkspaceButton(id=workspace_id, label=str(workspace_id))
+
+    def __init__(
+        self,
+        buttons: Iterable[WorkspaceButton] | None = None,
+        buttons_factory: Callable[[int], WorkspaceButton | None]
+        | None = default_buttons_factory,
+        invert_scroll: bool = False,
+        empty_scroll: bool = False,
+        **kwargs,
+    ):
+        super().__init__(events="scroll")
+        self.connection = get_hyprland_connection()
+        self._container = Box(**kwargs)
+        self.children = self._container
+
+        self._active_workspace: int | None = None
+        self._buttons: dict[int, WorkspaceButton] = {}
+        self._buttons_preset: list[WorkspaceButton] = [
+            button for button in buttons or ()
+        ]
+        self._buttons_factory = buttons_factory
+        self._invert_scroll = invert_scroll
+        self._empty_scroll = empty_scroll
+
+        bulk_connect(
+            self.connection,
+            {
+                "event::workspacev2": self.on_workspace,
+                "event::focusedmon": self.on_monitor,
+                "event::createworkspacev2": self.on_createworkspace,
+                "event::destroyworkspacev2": self.on_destroyworkspace,
+                "event::urgent": self.on_urgent,
+            },
+        )
+
+        # all aboard...
+        if self.connection.ready:
+            self.on_ready(None)
+        else:
+            self.connection.connect("event::ready", self.on_ready)
+        self.connect("scroll-event", self.scroll_handler)
+
+    def on_ready(self, _):
+        open_workspaces: tuple[int, ...] = tuple(
+            workspace["id"]
+            for workspace in json.loads(
+                str(self.connection.send_command("j/workspaces").reply.decode())
+            )
+        )
+        self._active_workspace = json.loads(
+            str(self.connection.send_command("j/activeworkspace").reply.decode())
+        )["id"]
+
+        for btn in self._buttons_preset:
+            self.insert_button(btn)
+
+        for id in open_workspaces:
+            if not (btn := self.lookup_or_bake_button(id)):
+                continue
+
+            btn.empty = False
+            if id == self._active_workspace:
+                btn.active = True
+
+            if btn in self._buttons_preset:
+                continue
+
+            self.insert_button(btn)
+        return
+
+    def on_monitor(self, _, event: HyprlandEvent):
+        if len(event.data) != 2:
+            return
+
+        active_workspace = int(event.data[1])
+
+        if self._active_workspace is not None and (
+            old_btn := self._buttons.get(self._active_workspace)
+        ):
+            old_btn.active = False
+
+        self._active_workspace = active_workspace
+        if not (btn := self.lookup_or_bake_button(active_workspace)):
+            return
+
+        btn.urgent = False
+        btn.active = True
+        return
+
+    def on_workspace(self, _, event: HyprlandEvent):
+        if len(event.data) != 2:
+            return
+
+        active_workspace = int(event.data[0])
+        if active_workspace == self._active_workspace:
+            return
+
+        if self._active_workspace is not None and (
+            old_btn := self._buttons.get(self._active_workspace)
+        ):
+            old_btn.active = False
+
+        self._active_workspace = active_workspace
+        if not (btn := self.lookup_or_bake_button(active_workspace)):
+            return
+
+        btn.urgent = False
+        btn.active = True
+
+        if btn in self._container.children:
+            return
+        return self.insert_button(btn)
+
+    def on_createworkspace(self, _, event: HyprlandEvent):
+        if len(event.data) != 2:
+            return
+        new_workspace = int(event.data[0])
+
+        if not (btn := self.lookup_or_bake_button(new_workspace)):
+            return
+
+        btn.empty = False
+        if btn in self._buttons_preset:
+            return
+        return self.insert_button(btn)
+
+    def on_destroyworkspace(self, _, event: HyprlandEvent):
+        if len(event.data) != 2:
+            return
+
+        destroyed_workspace = int(event.data[0])
+        if not (btn := self._buttons.get(destroyed_workspace)):
+            return  # doesn't exist, skip
+
+        btn.active = False
+        btn.urgent = False
+        btn.empty = True
+
+        if btn in self._buttons_preset:
+            return
+        return self.remove_button(btn)
+
+    def on_urgent(self, _, event: HyprlandEvent):
+        if len(event.data) != 1:
+            return
+
+        clients = json.loads(self.connection.send_command("j/clients").reply.decode())
+        clients_map = {client["address"]: client for client in clients}
+        urgent_client: dict = clients_map.get("0x" + event.data[0], {})
+        if not (raw_workspace := urgent_client.get("workspace")):
+            return logger.warning(
+                f"[Workspaces] received urgent signal, but data received ({event.data[0]}) is incorrect, skipping..."
+            )
+
+        urgent_workspace = int(raw_workspace["id"])
+        if not (btn := self._buttons.get(urgent_workspace)):
+            return  # doesn't exist, skip
+
+        btn.urgent = True
+        return logger.info(f"[Workspaces] workspace {urgent_workspace} is now urgent")
+
+    def scroll_handler(self, _, event: Gdk.EventScroll):
+        cmd = "" if self._empty_scroll else "e"
+        match event.direction:  # type: ignore
+            case Gdk.ScrollDirection.UP:
+                cmd += "-1" if self._invert_scroll is True else "+1"
+                logger.info("[Workspaces] Moving to the next workspace")
+            case Gdk.ScrollDirection.DOWN:
+                cmd += "+1" if self._invert_scroll is True else "-1"
+                logger.info("[Workspaces] Moving to the previous workspace")
+            case _:
+                return logger.warning(
+                    f"[Workspaces] Unknown scroll direction ({event.direction})"  # type: ignore
+                )
+        return self.connection.send_command(f"batch/dispatch workspace {cmd}")
+
+    def insert_button(self, button: WorkspaceButton) -> None:
+        self._buttons[button.id] = button
+        self._container.add(button)
+        button.connect("clicked", self.do_handle_button_press)
+        return self.reorder_buttons()
+
+    def reorder_buttons(self):
+        for _, child in sorted(self._buttons.items(), key=lambda i: i[0]):
+            self._container.reorder_child(child, (child.id - 1))
+        return
+
+    def remove_button(self, button: WorkspaceButton) -> None:
+        if self._buttons.pop(button.id, None) is not None:
+            self._container.remove(button)
+        return button.destroy()
+
+    def lookup_or_bake_button(self, workspace_id: int) -> WorkspaceButton | None:
+        if not (btn := self._buttons.get(workspace_id)):
+            if self._buttons_factory:
+                btn = self._buttons_factory(workspace_id)
+        return btn
+
+    def do_handle_button_press(self, button: WorkspaceButton):
+        self.connection.send_command(f"batch/dispatch workspace {button.id}")
+        return logger.info(f"[Workspaces] Moved to workspace {button.id}")
+
+
+class ActiveWindow(Button):
+    def __init__(
+        self,
+        formatter: FormattedString = FormattedString(
+            "{'Desktop' if not win_title else truncate(win_title, 42)}",
+            truncate=truncate,
+        ),
+        # TODO: hint super's kwargs
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.connection = get_hyprland_connection()
+        self.formatter = formatter
+
+        bulk_connect(
+            self.connection,
+            {
+                "event::activewindow": self.on_activewindow,
+                "event::closewindow": self.on_closewindow,
+            },
+        )
+
+        # all aboard...
+        if self.connection.ready:
+            self.on_ready(None)
+        else:
+            self.connection.connect("event::ready", self.on_ready)
+
+    def on_ready(self, _):
+        return self.do_initialize(), logger.info(
+            "[ActiveWindow] Connected to the hyprland socket"
+        )
+
+    def on_closewindow(self, _, event: HyprlandEvent):
+        if len(event.data) < 1:
+            return
+        return self.do_initialize(), logger.info(
+            f"[ActiveWindow] Closed window 0x{event.data[0]}"
+        )
+
+    def on_activewindow(self, _, event: HyprlandEvent):
+        if len(event.data) < 2:
+            return
+        return self.set_label(
+            self.formatter.format(win_class=event.data[0], win_title=event.data[1])
+        ), logger.info(
+            f"[ActiveWindow] Activated window {event.data[0]}, {event.data[1]}"
+        )
+
+    def do_initialize(self):
+        win_data: dict = json.loads(
+            self.connection.send_command("j/activewindow").reply.decode()
+        )
+        win_class = win_data.get("class", "unknown")
+        win_title = win_data.get("title", win_class)
+
+        return self.set_label(
+            self.formatter.format(win_class=win_class, win_title=win_title)
+        )
+
+
+class Language(Button):
+    def __init__(
+        self,
+        keyboard: str = ".*",
+        formatter: FormattedString = FormattedString("{language}"),
+        # TODO: hint super's kwargs
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.connection = get_hyprland_connection()
+        self.keyboard = keyboard
+        self.formatter = formatter
+
+        self.connection.connect("event::activelayout", self.on_activelayout)
+
+        # all aboard...
+        if self.connection.ready:
+            self.on_ready(None)
+        else:
+            self.connection.connect("event::ready", self.on_ready)
+
+    def on_ready(self, _):
+        return self.do_initialize(), logger.info(
+            "[Language] Connected to the hyprland socket"
+        )
+
+    def on_activelayout(self, _, event: HyprlandEvent):
+        if len(event.data) < 2:
+            return logger.warning(
+                f"[Language] got invalid event data from hyprland, raw data is\n{event.raw_data}"
+            )
+        keyboard, language = event.data
+        matched: bool = False
+
+        if re.match(self.keyboard, keyboard) and (matched := True):
+            self.set_label(self.formatter.format(language=language))
+
+        return logger.debug(
+            f"[Language] Keyboard: {keyboard}, Language: {language}, Match: {matched}"
+        )
+
+    def do_initialize(self):
+        devices: dict[str, list[dict[str, str]]] = json.loads(
+            str(self.connection.send_command("j/devices").reply.decode())
+        )
+        if not devices or not (keyboards := devices.get("keyboards")):
+            return logger.warning(
+                f"[Language] coulnd't get devices from hyprctl, gotten data\n{devices}"
+            )
+
+        language: str | None = None
+        for kb in keyboards:
+            if (
+                not (kb_name := kb.get("name"))
+                or not re.match(self.keyboard, kb_name)
+                or not (language := kb.get("active_keymap"))
+            ):
+                continue
+
+            self.set_label(self.formatter.format(language=language))
+            logger.debug(
+                f"[Language] found language: {language} for keyboard {kb_name}"
+            )
+            break
+
+        return (
+            logger.info(
+                f"[Language] Could not find language for keyboard: {self.keyboard}, gotten keyboards: {keyboards}"
+            )
+            if not language
+            else logger.info(
+                f"[Language] Set language: {language} for keyboard: {self.keyboard}"
+            )
+        )

--- a/fabric/utils/helpers.py
+++ b/fabric/utils/helpers.py
@@ -39,13 +39,13 @@ class __DeprecationHook__:
     def __init__(self, deprecated_to_replacement: dict[str, str]):
         self.lookup_table = deprecated_to_replacement
 
-    def __call__(self, additional_message: str | None = None):
+    def __call__(self):
         if replacement := self.lookup_table.get(
             (caller := inspect.currentframe().f_back.f_code.co_name),  # type: ignore
             None,
         ):
             return logger.warning(
-                f"the function `{caller}` is deprecated and will removed in later versions of Fabric, consider using `{replacement}` instead"
+                f"the function `{caller}` is deprecated and will be removed in future versions of Fabric, consider using `{replacement}` instead"
             )
         return
 


### PR DESCRIPTION
> [!WARNING]
> Once this PR is merged widgets `import`ed from `fabric.hyprland.widgets` are going to be prefixed with `Hyprland`
> Example: `Workspaces` is now `HyprlandWorkspaces`, `Language` is now `HyprlandLanguage` and `ActiveWindow` is now `HyprlandActiveWindow`. `WorkspaceButton` is still as-is since it is a shared widget imported from `fabric.core.wm`.