### PR TITLE
fix: system tray not using default icon theme

### DIFF
--- a/fabric/system_tray/service.py
+++ b/fabric/system_tray/service.py
@@ -241,7 +241,7 @@ class SystemTrayItem(Service):
     @Property(Gtk.IconTheme, "readable")
     def icon_theme(self) -> Gtk.IconTheme:
         if not self._icon_theme:
-            self._icon_theme = Gtk.IconTheme()
+            self._icon_theme = Gtk.IconTheme.get_default()
             search_path = self.get_icon_theme_path()
             self._icon_theme.set_search_path([search_path]) if search_path not in (
                 None,


### PR DESCRIPTION
This PR makes the Fabric system tray service use the configured default GTK icon theme as recommended in [the documentation](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/IconTheme.html)

It may also fix Issue #96 (I didn't test the specific application), since it resolves a similar error for me: 

```
Traceback (most recent call last):
  File ".../fabric/.venv/lib/python3.13/site-packages/fabric/utils/helpers.py", line 903, in wrapper
    return func(*passed_args[:args_len])
  File ".../fabric/.venv/lib/python3.13/site-packages/fabric/system_tray/widgets.py", line 79, in on_item_added
    item_button = SystemTrayItem(item, self._icon_size)
  File ".../fabric/.venv/lib/python3.13/site-packages/fabric/system_tray/widgets.py", line 33, in __init__
    self.do_update_properties()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File ".../fabric/.venv/lib/python3.13/site-packages/fabric/system_tray/widgets.py", line 36, in do_update_properties
    pixbuf = self._item.get_preferred_icon_pixbuf(self._icon_size)
  File ".../fabric/.venv/lib/python3.13/site-packages/fabric/system_tray/service.py", line 195, in get_preferred_icon_pixbuf
    else icon_theme.load_icon(
         ~~~~~~~~~~~~~~~~~~~~^
        preferred_icon_name,
        ^^^^^^^^^^^^^^^^^^^^
        max(icon_theme_sizes),
        ^^^^^^^^^^^^^^^^^^^^^^
        Gtk.IconLookupFlags.FORCE_SIZE,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
gi.repository.GLib.GError: gtk-icon-theme-error-quark: Icon 'drive-removable-media-usb-panel' not present in theme (null) (0)
```
