### PR TITLE
Improve performance of get_relative_path

### DIFF
--- a/fabric/utils/helpers.py
+++ b/fabric/utils/helpers.py
@@ -1,6 +1,7 @@
 import gi
 import re
 import os
+import sys
 import time
 import math
 import cairo
@@ -754,7 +755,22 @@ def get_relative_path(path: str, level: int = 1) -> str:
     :return: the relative path
     :rtype: str
     """
-    prev_globals = inspect.stack()[level][0].f_globals
+
+    frame = None
+
+    # Use sys._getframe if available 
+    getframe = getattr(sys, "_getframe", None)
+    if getframe is not None:
+        try:
+            frame = getframe(level)
+        except ValueError:
+            frame = None
+
+    # Fallback
+    if frame is None:
+        frame = inspect.stack()[level][0]
+
+    prev_globals = frame.f_globals
     file_var = (
         os.path.dirname(os.path.abspath(prev_globals["__file__"]))
         if "__file__" in prev_globals


### PR DESCRIPTION
inspect.stack() is extremely slow. Using _getframe on cpython is way faster. Wasn't able to test pypy's _getframe but can't imagine it being slower than getting the entire stack.

This change lowered real life CPU usage in ax-shell in idle from about 3% to 1.5% on my system. Could avoid using this function in ax-shell but fabric itself uses it in many places so fixing it upstream would be perfect.

Used Austin to find the bottleneck if someone wants to confirm the issue.