### PR TITLE
Fix logic error in SVG set_style

### DIFF
--- a/fabric/widgets/svg.py
+++ b/fabric/widgets/svg.py
@@ -129,7 +129,7 @@ class Svg(Gtk.DrawingArea, Widget):
         rect.width = width  # type: ignore
         rect.height = height  # type: ignore
 
-        if self._style_compiled is not None and self._handle.set_stylesheet(
+        if self._style_compiled is not None and not self._handle.set_stylesheet(
             self._style_compiled.encode()  # type: ignore
         ):
             logger.error("[Svg] failed to apply style, probably invalid style property")


### PR DESCRIPTION
Setting a style on an `Svg`  prints a warning even if the styles are correct. 

## Reproducer

The following script shows the error. The circle is correctly styled (red fill), but a warning is printed in the console.  

The following script shows the error:

```py
from fabric import Application
from fabric.widgets.box import Box
from fabric.widgets.svg import Svg
from fabric.widgets.window import Window

# Simple SVG with a circle
SIMPLE_SVG = """
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
    <circle cx="50" cy="50" r="40" fill="black"/>
</svg>
"""

SVG_STYLE = """
circle {
    fill: red;
}
"""

def run():
    # Create SVG widget with inline SVG
    svg_widget = Svg(
        svg_string=SIMPLE_SVG,
        size=100,
    )
    svg_widget.set_style(SVG_STYLE)

    window = Window(
        child=Box(
            children=[svg_widget],
        ),
        all_visible=True,
    )

    app = Application("svg-bug-test", window)
    app.run()

if __name__ == "__main__":
    run()
```

Running it, results in 

```console 
[Svg] failed to apply style, probably invalid style property
```

## The bug

In `Svg.set_style`, the success check fails when `set_stylesheet` returns a truthy value. This is an error since the call returns `False` on error. When the check is patched, errors are no longer shown for valid styles. 

