### PR TITLE
refactor: tooltip setting logic for clarity

### DIFF
--- a/fabric/system_tray/widgets.py
+++ b/fabric/system_tray/widgets.py
@@ -41,9 +41,10 @@ class SystemTrayItem(Button):
 
         tooltip = self._item.tooltip
         self.set_tooltip_markup(
-            tooltip.description or tooltip.title or self._item.title.title()
-            if self._item.title
-            else "Unknown"
+            tooltip.description or 
+            tooltip.title or 
+            (self._item.title.title() if self._item.title else None) or 
+            "Unknown"
         )
         return
 


### PR DESCRIPTION
Some apps such as Vesktop are still being shown as "Unknown"

