### PR TITLE
feat: implement `CircularScale` widget

### DIFF
--- a/examples/animated-circular-scale-widget/config.py
+++ b/examples/animated-circular-scale-widget/config.py
@@ -1,0 +1,93 @@
+import gi
+from fabric import Application
+from fabric.widgets.box import Box
+from fabric.widgets.scale import Scale
+from fabric.widgets.label import Label
+from fabric.widgets.x11 import X11Window as Window
+from fabric.widgets.circularscale import CircularScale
+from fabric.utils import get_relative_path, monitor_file
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, Gdk # type: ignore
+
+class AnimatedCircularScale(CircularScale):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.animator = (
+            Animator(
+                # edit the following parameters to customize the animation
+                bezier_curve=(0.15, 0.88, 0.68, 0.95),
+                duration=0.8,
+                min_value=self.min_value,
+                max_value=self.value,
+                tick_widget=self,
+                notify_value=lambda p, *_: self.set_value(p.value),
+            )
+            .build()
+            .play()
+            .unwrap()
+        )
+
+    def animate_value(self, value: float):
+        self.animator.pause()
+        self.animator.min_value = self.value
+        self.animator.max_value = value
+        self.animator.play()
+        return
+
+
+if __name__ == "__main__":
+    DEFAULT = 50
+
+    scale = AnimatedCircularScale(
+        name="demo-circular-scale",
+        min_value=0,
+        max_value=100,
+        start_angle=-90,
+        end_angle=270,
+        h_expand=True,
+        v_expand=True,
+        child=Label(),
+    )
+
+    h_scale = Scale(
+        name="demo-scale",
+        orientation="h",
+        min_value=0,
+        max_value=100,
+        increments=(1, 1),
+    )
+    h_scale.connect("value-changed", lambda s: scale.animate_value(s.get_value()))
+    
+    # init
+    h_scale.set_value(DEFAULT)
+
+    def on_value_change(widget, value):
+        if child := widget.get_child():
+            child.set_text(f"{int(widget.value)}%")
+
+    scale.connect("notify::value", on_value_change)
+
+    desktop_widget = Window(
+        type_hint="normal",
+        geometry="center",
+        child=Box(
+            name="container-box",
+            orientation="v",
+            size=250,
+            spacing=10,
+            children=[scale, h_scale],
+        ),
+        all_visible=True,
+    )
+
+    app = Application("desktop-widget", desktop_widget)
+
+    def set_css(*args):
+        app.set_stylesheet_from_file(get_relative_path("style.css"))
+
+    app.style_monitor = monitor_file(get_relative_path("./style.css"))
+    app.style_monitor.connect("changed", set_css)
+    set_css()
+
+    app.run()

--- a/examples/animated-circular-scale-widget/style.css
+++ b/examples/animated-circular-scale-widget/style.css
@@ -1,0 +1,60 @@
+* {
+  all: unset;
+}
+
+:vars {
+  --primary: #8bda76;
+  --surface-bright: #363b33;
+  --surface: #10150e;
+  --on-primary: #023900;
+}
+
+/* circular scale */
+#demo-circular-scale slider {
+  background-color: var(--primary);
+  min-width: 20px;
+  min-height: 40px;
+  margin-left: 15px;
+  margin-right: 15px;
+  border-radius: 50px;
+}
+#demo-circular-scale highlight {
+  background-color: var(--primary);
+  /* max of width/height/border size */
+  min-width: 24px;
+}
+#demo-circular-scale trough {
+  background-color: var(--surface-bright);
+  /* max of width/height/border size */
+  border: 12px solid;
+}
+#demo-circular-scale {
+    background-color: transparent;
+}
+
+/* scale */
+#demo-scale slider {
+  background-color: var(--on-primary);
+  min-width: 10px;
+  min-height: 10px;
+  margin: 0px 20px 0px 0px;
+  border-radius: 100%;
+}
+#demo-scale highlight {
+  background-color: var(--primary);
+  border-radius: 20px 20px 20px 20px;
+  margin-left: -20px;
+}
+#demo-scale trough {
+  background-color: var(--surface-bright);
+  border-radius: 20px;
+  min-width: 20px;
+  min-height: 20px;
+  padding-left: 20px;
+}
+
+/* container */
+#container-box {
+  padding: 20px;
+  background-color: var(--surface);
+}

--- a/fabric/widgets/circularscale.py
+++ b/fabric/widgets/circularscale.py
@@ -1,7 +1,7 @@
 import gi
 import math
 import cairo
-from typing import Literal, Iterable
+from typing import Iterable, Literal, Tuple
 from fabric.widgets.circularprogressbar import CircularProgressBar
 from fabric.utils.helpers import clamp
 
@@ -10,59 +10,122 @@ from gi.repository import Gdk, Gtk, GObject
 
 
 class CircularScale(CircularProgressBar):
-    NON_ROUND_CAP_DELTA = 0.01
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        cap_delta: float = 0.01,
+        value: float = 1.0,
+        min_value: float = 0.0,
+        max_value: float = 1.0,
+        start_angle: float | None = None,
+        end_angle: float | None = None,
+        line_width: int = 4,
+        line_style: (
+            Literal["none", "butt", "round", "square"] | cairo.LineCap
+        ) = cairo.LineCap.ROUND,
+        pie: bool = False,
+        invert: bool = False,
+        child: Gtk.Widget | None = None,
+        name: str | None = None,
+        visible: bool = True,
+        all_visible: bool = False,
+        style: str | None = None,
+        style_classes: Iterable[str] | str | None = None,
+        tooltip_text: str | None = None,
+        tooltip_markup: str | None = None,
+        h_align: (
+            Literal["fill", "start", "end", "center", "baseline"] | Gtk.Align | None
+        ) = None,
+        v_align: (
+            Literal["fill", "start", "end", "center", "baseline"] | Gtk.Align | None
+        ) = None,
+        h_expand: bool = False,
+        v_expand: bool = False,
+        size: Iterable[int] | int | None = None,
+        **kwargs,
+    ):
+        self.cap_delta = cap_delta
+        super().__init__(
+            value=value,
+            min_value=min_value,
+            max_value=max_value,
+            start_angle=start_angle,
+            end_angle=end_angle,
+            line_width=line_width,
+            line_style=line_style,
+            pie=pie,
+            invert=invert,
+            child=child,
+            name=name,
+            visible=visible,
+            all_visible=all_visible,
+            style=style,
+            style_classes=style_classes,
+            tooltip_text=tooltip_text,
+            tooltip_markup=tooltip_markup,
+            h_align=h_align,
+            v_align=v_align,
+            h_expand=h_expand,
+            v_expand=v_expand,
+            size=size,
+            **kwargs,
+        )
         # gadgets
-        self.trough_ctx = self.do_create_gadget_context("trough")
-        self.slider_ctx = self.do_create_gadget_context("slider")
-        self.highlight_ctx = self.do_create_gadget_context("highlight")
+        self._trough_ctx = self.do_create_gadget_context("trough")
+        self._slider_ctx = self.do_create_gadget_context("slider")
+        self._highlight_ctx = self.do_create_gadget_context("highlight")
 
-    def do_get_thickness_from_context(self, context, state):
-        border = context.get_border(state)
+    def do_get_border_width(
+        self, context: Gtk.StyleContext, state: Gtk.StateFlags
+    ) -> float:
+        border = context.get_border(state)  # type: ignore
         return max(
             self._line_width,
-            border.top,
-            border.bottom,
-            border.left,
-            border.right,
-            context.get_property("min-width", state),
-            context.get_property("min-height", state),
+            border.top,  # type: ignore
+            border.bottom,  # type: ignore
+            border.left,  # type: ignore
+            border.right,  # type: ignore
+            context.get_property("min-width", state),  # type: ignore
+            context.get_property("min-height", state),  # type: ignore
         )
 
     def do_calculate_safe_radius(
-        self, delta, slider_height, progress_thickness, trough_thickness
-    ):
-        max_thickness = max(slider_height, progress_thickness, trough_thickness)
-        return max(delta - max_thickness / 2, 0)
+        self,
+        radius: float,
+        slider_height: float,
+        progress_thickness: float,
+        trough_thickness: float,
+    ) -> float:
+        return max(
+            radius - max(slider_height, progress_thickness, trough_thickness) / 2, 0
+        )
 
-    def do_normalize_value(self):
+    def do_normalize_value(self) -> float:
         value_range = self._max_value - self._min_value
         if value_range == 0:
             return 0.0
         return clamp((self._value - self._min_value) / value_range, 0.0, 1.0)
-    
-    def do_get_arc_delta(self):
+
+    def do_get_arc_delta(self) -> float:
         # add a tiny delta to force the rendering of line caps. (square and butt)
-        return self.NON_ROUND_CAP_DELTA if self.line_style != cairo.LineCap.ROUND else 0
+        return self.cap_delta if self.line_style != cairo.LineCap.ROUND else 0.0
 
     def do_draw_progress_arc(
         self,
-        cr,
-        center_x,
-        center_y,
-        safe_radius,
-        start_angle,
-        progress_thickness,
-        progress_angle,
-        progress_color,
-        progress_line_width_angle,
-        slider_thickness_angle,
-        left_gap_angle,
-    ):
+        cr: cairo.Context,
+        center_x: float,
+        center_y: float,
+        radius: float,
+        start_angle: float,
+        progress_thickness: float,
+        progress_angle: float,
+        progress_color: Gdk.RGBA,
+        slider_thickness_angle: float,
+        left_gap_angle: float,
+    ) -> None:
         cr.set_line_width(progress_thickness)
         Gdk.cairo_set_source_rgba(cr, progress_color)
+
+        progress_line_width_angle = progress_thickness / radius
 
         if progress_angle - progress_line_width_angle - left_gap_angle > start_angle:
             # draw normal arc
@@ -74,46 +137,37 @@ class CircularScale(CircularProgressBar):
                 - (progress_line_width_angle / 2 + slider_thickness_angle / 2)
                 - left_gap_angle
             )
-            cr.arc(center_x, center_y, safe_radius, arc_start, arc_end)
+            cr.arc(center_x, center_y, radius, arc_start, arc_end)
             cr.stroke()
-        else:
-            # draw shrinking dot when available space is minimal
-            ratio = progress_line_width_angle / (
-                progress_line_width_angle + left_gap_angle
-            )
-            dot_arc = (
-                -(
-                    start_angle
-                    - slider_thickness_angle / 2
-                    - (progress_angle - slider_thickness_angle / 2)
-                )
-                / 2
-                * ratio
-            )
-            dot_radius = 2 * safe_radius * math.sin(dot_arc)
+            return
 
-            cr.set_line_width(dot_radius)
-            true_start = start_angle - slider_thickness_angle / 2 + dot_arc
-            delta = self.do_get_arc_delta()
-            cr.arc(center_x, center_y, safe_radius, true_start, true_start + delta)
-            cr.stroke()
-            cr.set_line_width(safe_radius * progress_line_width_angle)
+        # draw shrinking dot when available space is minimal
+        ratio = progress_line_width_angle / (progress_line_width_angle + left_gap_angle)
+        dot_arc = -(start_angle - progress_angle) / 2 * ratio
+        dot_radius = 2 * radius * math.sin(dot_arc)
+
+        cr.set_line_width(dot_radius)
+        true_start = start_angle - slider_thickness_angle / 2 + dot_arc
+        delta = self.do_get_arc_delta()
+        cr.arc(center_x, center_y, radius, true_start, true_start + delta)
+        cr.stroke()
+        cr.set_line_width(radius * progress_line_width_angle)
 
     def do_draw_slider(
         self,
-        cr,
-        center_x,
-        center_y,
-        safe_radius,
-        progress_angle,
-        slider_color,
-        slider_thickness_angle,
-        slider_height,
-        corner_radius,
-    ):
+        cr: cairo.Context,
+        center_x: float,
+        center_y: float,
+        radius: float,
+        progress_angle: float,
+        slider_color: Gdk.RGBA,
+        slider_thickness_angle: float,
+        slider_height: float,
+        corner_radius: float | Tuple[float, float, float, float],
+    ) -> None:
         angle_rad = progress_angle
-        sx = center_x + math.cos(angle_rad) * safe_radius
-        sy = center_y + math.sin(angle_rad) * safe_radius
+        sx = center_x + math.cos(angle_rad) * radius
+        sy = center_y + math.sin(angle_rad) * radius
 
         cr.save()
         cr.translate(sx, sy)
@@ -123,9 +177,9 @@ class CircularScale(CircularProgressBar):
 
         self.do_draw_rounded_rect(
             cr,
-            -(slider_thickness_angle * safe_radius) / 2,
+            -(slider_thickness_angle * radius) / 2,
             -slider_height / 2,
-            slider_thickness_angle * safe_radius,
+            slider_thickness_angle * radius,
             slider_height,
             corner_radius,
         )
@@ -134,20 +188,21 @@ class CircularScale(CircularProgressBar):
 
     def do_draw_trough_arc(
         self,
-        cr,
-        center_x,
-        center_y,
-        safe_radius,
-        progress_angle,
-        real_end_angle,
-        trough_color,
-        trough_thickness,
-        trough_line_width_angle,
-        slider_thickness_angle,
-        right_gap_angle,
-    ):
+        cr: cairo.Context,
+        center_x: float,
+        center_y: float,
+        radius: float,
+        progress_angle: float,
+        real_end_angle: float,
+        trough_color: Gdk.RGBA,
+        trough_thickness: float,
+        slider_thickness_angle: float,
+        right_gap_angle: float,
+    ) -> None:
         cr.set_line_width(trough_thickness)
         Gdk.cairo_set_source_rgba(cr, trough_color)
+
+        trough_line_width_angle = trough_thickness / radius
 
         remaining_start = (
             progress_angle + trough_line_width_angle / 2 + slider_thickness_angle / 2
@@ -161,185 +216,69 @@ class CircularScale(CircularProgressBar):
             cr.arc(
                 center_x,
                 center_y,
-                safe_radius,
+                radius,
                 remaining_start + right_gap_angle,
                 remaining_end,
             )
             cr.stroke()
-        else:
-            # draw shrinking dot when remaining space is minimal
-            ratio = trough_line_width_angle / (
-                trough_line_width_angle + right_gap_angle
-            )
-            true_end = real_end_angle - slider_thickness_angle / 2
-            remaining_angle = true_end - (progress_angle + slider_thickness_angle / 2)
-            remaining_usable_angle = max(remaining_angle, 0.0) * ratio
-
-            chord_length = 2 * safe_radius * math.sin(remaining_usable_angle / 2)
-            cr.set_line_width(chord_length)
-
-            mid_angle = (
-                progress_angle
-                + slider_thickness_angle / 2
-                + remaining_angle * (1 - ratio)
-                + remaining_usable_angle / 2
-            )
-            delta = self.do_get_arc_delta()
-            cr.arc(center_x, center_y, safe_radius, mid_angle, mid_angle + delta)
-            cr.stroke()
-
-    def do_draw(self, cr: cairo.Context):
-        state = self.get_state_flags()
-        style_context = self.get_style_context()
-
-        border = style_context.get_border(state)
-        background_color = style_context.get_background_color(state)
-
-        width = self.get_allocated_width()
-        height = self.get_allocated_height()
-        center_x = width / 2
-        center_y = height / 2
-
-        # slider properties
-        slider_color = self.slider_ctx.get_background_color(state)
-        slider_height = self.slider_ctx.get_property("min-height", state)
-        slider_thickness = self.slider_ctx.get_property("min-width", state)
-        left_gap = self.slider_ctx.get_property("margin-left", state)
-        right_gap = self.slider_ctx.get_property("margin-right", state)
-        corner_radius = self.slider_ctx.get_property("border-radius", state)
-
-        # progress (highlight) properties
-        progress_color = self.highlight_ctx.get_background_color(state)
-        progress_thickness = self.do_get_thickness_from_context(self.highlight_ctx, state)
-
-        # trough properties
-        trough_color = self.trough_ctx.get_background_color(state)
-        trough_thickness = self.do_get_thickness_from_context(self.trough_ctx, state)
-
-        # calculate radius
-        radius = self.do_calculate_radius()
-        safe_radius = self.do_calculate_safe_radius(
-            radius, slider_height, progress_thickness, trough_thickness
-        )
-        if safe_radius == 0:
-            if child := self.get_child():
-                self.propagate_draw(child, cr)
             return
 
-        cr.save()
-        cr.set_line_cap(self._line_style)
+        # draw shrinking dot when remaining space is minimal
+        ratio = trough_line_width_angle / (trough_line_width_angle + right_gap_angle)
+        remaining_angle = real_end_angle - (slider_thickness_angle + progress_angle)
+        remaining_usable_angle = max(remaining_angle, 0.0) * ratio
 
-        # background fill
-        cr.set_line_width(0)
-        Gdk.cairo_set_source_rgba(cr, background_color)
-        cr.arc(center_x, center_y, radius, 0, 2 * math.pi)
-        cr.fill()
+        chord_length = 2 * radius * math.sin(remaining_usable_angle / 2)
+        cr.set_line_width(chord_length)
 
-        # angles (S = r*theta)
-        left_gap_angle = left_gap / safe_radius
-        right_gap_angle = right_gap / safe_radius
-        progress_line_width_angle = progress_thickness / safe_radius
-        trough_line_width_angle = trough_thickness / safe_radius
-        slider_thickness_angle = slider_thickness / safe_radius
-
-        start_angle = math.radians(self._start_angle)
-        end_angle = (
-            math.radians(self._end_angle) - slider_thickness_angle - right_gap_angle
+        mid_angle = (
+            progress_angle
+            + slider_thickness_angle / 2
+            + remaining_angle * (1 - ratio)
+            + remaining_usable_angle / 2
         )
-        real_end_angle = math.radians(self._end_angle) - right_gap_angle
+        delta = self.do_get_arc_delta()
+        cr.arc(center_x, center_y, radius, mid_angle, mid_angle + delta)
+        cr.stroke()
 
-        normalized_value = self.do_normalize_value()
-        progress_angle = start_angle + normalized_value * (end_angle - start_angle)
-
-        # exposed for override
-        self.do_draw_progress_arc(
-            cr=cr,
-            center_x=center_x,
-            center_y=center_y,
-            safe_radius=safe_radius,
-            start_angle=start_angle,
-            progress_angle=progress_angle,
-            progress_color=progress_color,
-            progress_thickness=progress_thickness,
-            progress_line_width_angle=progress_line_width_angle,
-            slider_thickness_angle=slider_thickness_angle,
-            left_gap_angle=left_gap_angle,
-        )
-
-        self.do_draw_slider(
-            cr=cr,
-            center_x=center_x,
-            center_y=center_y,
-            safe_radius=safe_radius,
-            progress_angle=progress_angle,
-            slider_color=slider_color,
-            slider_thickness_angle=slider_thickness_angle,
-            slider_height=slider_height,
-            corner_radius=corner_radius,
-        )
-
-        self.do_draw_trough_arc(
-            cr=cr,
-            center_x=center_x,
-            center_y=center_y,
-            safe_radius=safe_radius,
-            progress_angle=progress_angle,
-            real_end_angle=real_end_angle,
-            trough_color=trough_color,
-            trough_thickness=trough_thickness,
-            trough_line_width_angle=trough_line_width_angle,
-            slider_thickness_angle=slider_thickness_angle,
-            right_gap_angle=right_gap_angle,
-        )
-
-        # draw child (if any)
-        if child := self.get_child():
-            self.propagate_draw(child, cr)
-
-        cr.restore()
-        return False
-
-    def do_create_gadget_context(self, node_name):
+    def do_create_gadget_context(self, node_name: str) -> Gtk.StyleContext:
         ctx = Gtk.StyleContext()
-        ctx.set_parent(self.get_style_context())
+        ctx.set_parent(self.get_style_context())  # type: ignore
 
-        path = self.get_style_context().get_path().copy()
+        path = self.get_style_context().get_path().copy()  # type: ignore
         path.append_type(GObject.TYPE_NONE)
         path.iter_set_object_name(-1, node_name)
 
         ctx.connect("changed", lambda _: self.queue_draw())
-        ctx.set_path(path)
+        ctx.set_path(path)  # type: ignore
         return ctx
 
-    def do_draw_rounded_rect(self, cr, x, y, width, height, radius):
+    def do_draw_rounded_rect(
+        self,
+        cr: cairo.Context,
+        x: float,
+        y: float,
+        width: float,
+        height: float,
+        radius: float | Tuple[float, float, float, float],
+    ) -> None:
         if isinstance(radius, (int, float)):
             rtl = rtr = rbr = rbl = float(radius)
         else:
             rtl, rtr, rbr, rbl = map(float, radius)
 
-        rtl, rtr, rbr, rbl = [max(0.0, v) for v in [rtl, rtr, rbr, rbl]]
+        rtl, rtr, rbr, rbl = (max(0.0, v) for v in (rtl, rtr, rbr, rbl))
 
         # for scaling down overflowing corner radius
-        factor = 1.0
+        factor = min(
+            1.0,
+            width / (rtl + rtr) if (rtl + rtr) > width else 1.0,  # top edge
+            width / (rbl + rbr) if (rbl + rbr) > width else 1.0,  # bottom edge
+            height / (rtl + rbl) if (rtl + rbl) > height else 1.0,  # left edge
+            height / (rtr + rbr) if (rtr + rbr) > height else 1.0,  # right edge
+        )
 
-        # top edge
-        if (rtl + rtr) > width:
-            factor = min(factor, width / (rtl + rtr))
-        # bottom edge
-        if (rbl + rbr) > width:
-            factor = min(factor, width / (rbl + rbr))
-        # left edge
-        if (rtl + rbl) > height:
-            factor = min(factor, height / (rtl + rbl))
-        # right edge
-        if (rtr + rbr) > height:
-            factor = min(factor, height / (rtr + rbr))
-
-        if factor < 1.0:
-            rtl *= factor
-            rtr *= factor
-            rbr *= factor
-            rbl *= factor
+        rtl, rtr, rbr, rbl = (r * factor for r in (rtl, rtr, rbr, rbl))
 
         cr.new_sub_path()
 
@@ -371,3 +310,109 @@ class CircularScale(CircularProgressBar):
             cr.arc(x + rtl, y + rtl, rtl, math.pi, 3 * math.pi / 2)
 
         cr.close_path()
+
+    def do_draw(self, cr: cairo.Context) -> None:
+        state = self.get_state_flags()
+        style_context = self.get_style_context()
+
+        background_color = style_context.get_background_color(state)  # type: ignore
+
+        width = self.get_allocated_width()
+        height = self.get_allocated_height()
+        center_x = width / 2
+        center_y = height / 2
+
+        # slider properties
+        slider_color = self._slider_ctx.get_background_color(state)  # type: ignore
+        slider_height = self._slider_ctx.get_property("min-height", state)  # type: ignore
+        slider_thickness = self._slider_ctx.get_property("min-width", state)  # type: ignore
+        left_gap = self._slider_ctx.get_property("margin-left", state)  # type: ignore
+        right_gap = self._slider_ctx.get_property("margin-right", state)  # type: ignore
+        corner_radius = self._slider_ctx.get_property("border-radius", state)  # type: ignore
+
+        # progress (highlight) properties
+        progress_color = self._highlight_ctx.get_background_color(state)  # type: ignore
+        progress_thickness = self.do_get_border_width(self._highlight_ctx, state)
+
+        # trough properties
+        trough_color = self._trough_ctx.get_background_color(state)  # type: ignore
+        trough_thickness = self.do_get_border_width(self._trough_ctx, state)
+
+        # calculate radius
+        radius = self.do_calculate_radius()
+        safe_radius = self.do_calculate_safe_radius(
+            radius, slider_height, progress_thickness, trough_thickness
+        )
+        if safe_radius == 0:
+            if child := self.get_child():
+                self.propagate_draw(child, cr)
+            return
+
+        cr.save()
+        cr.set_line_cap(self._line_style)
+
+        # background fill
+        cr.set_line_width(0)
+        Gdk.cairo_set_source_rgba(cr, background_color)
+        cr.arc(center_x, center_y, radius, 0, 2 * math.pi)
+        cr.fill()
+
+        # angles (S = r*theta)
+        left_gap_angle = left_gap / safe_radius
+        right_gap_angle = right_gap / safe_radius
+        slider_thickness_angle = slider_thickness / safe_radius
+
+        start_angle = math.radians(self._start_angle)
+        end_angle = (
+            math.radians(self._end_angle) - slider_thickness_angle - right_gap_angle
+        )
+        real_end_angle = math.radians(self._end_angle) - right_gap_angle
+
+        normalized_value = self.do_normalize_value()
+        progress_angle = start_angle + normalized_value * (end_angle - start_angle)
+
+        # exposed for override
+        self.do_draw_progress_arc(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            radius=safe_radius,
+            start_angle=start_angle,
+            progress_angle=progress_angle,
+            progress_color=progress_color,
+            progress_thickness=progress_thickness,
+            slider_thickness_angle=slider_thickness_angle,
+            left_gap_angle=left_gap_angle,
+        )
+
+        self.do_draw_slider(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            radius=safe_radius,
+            progress_angle=progress_angle,
+            slider_color=slider_color,
+            slider_thickness_angle=slider_thickness_angle,
+            slider_height=slider_height,
+            corner_radius=corner_radius,
+        )
+
+        self.do_draw_trough_arc(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            radius=safe_radius,
+            progress_angle=progress_angle,
+            real_end_angle=real_end_angle,
+            trough_color=trough_color,
+            trough_thickness=trough_thickness,
+            slider_thickness_angle=slider_thickness_angle,
+            right_gap_angle=right_gap_angle,
+        )
+
+        # draw child (if any)
+        if child := self.get_child():
+            self.propagate_draw(child, cr)
+
+        cr.restore()
+        return

--- a/fabric/widgets/circularscale.py
+++ b/fabric/widgets/circularscale.py
@@ -1,0 +1,373 @@
+import gi
+import math
+import cairo
+from typing import Literal, Iterable
+from fabric.widgets.circularprogressbar import CircularProgressBar
+from fabric.utils.helpers import clamp
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, Gtk, GObject
+
+
+class CircularScale(CircularProgressBar):
+    NON_ROUND_CAP_DELTA = 0.01
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # gadgets
+        self.trough_ctx = self.do_create_gadget_context("trough")
+        self.slider_ctx = self.do_create_gadget_context("slider")
+        self.highlight_ctx = self.do_create_gadget_context("highlight")
+
+    def do_get_thickness_from_context(self, context, state):
+        border = context.get_border(state)
+        return max(
+            self._line_width,
+            border.top,
+            border.bottom,
+            border.left,
+            border.right,
+            context.get_property("min-width", state),
+            context.get_property("min-height", state),
+        )
+
+    def do_calculate_safe_radius(
+        self, delta, slider_height, progress_thickness, trough_thickness
+    ):
+        max_thickness = max(slider_height, progress_thickness, trough_thickness)
+        return max(delta - max_thickness / 2, 0)
+
+    def do_normalize_value(self):
+        value_range = self._max_value - self._min_value
+        if value_range == 0:
+            return 0.0
+        return clamp((self._value - self._min_value) / value_range, 0.0, 1.0)
+    
+    def do_get_arc_delta(self):
+        # add a tiny delta to force the rendering of line caps. (square and butt)
+        return self.NON_ROUND_CAP_DELTA if self.line_style != cairo.LineCap.ROUND else 0
+
+    def do_draw_progress_arc(
+        self,
+        cr,
+        center_x,
+        center_y,
+        safe_radius,
+        start_angle,
+        progress_thickness,
+        progress_angle,
+        progress_color,
+        progress_line_width_angle,
+        slider_thickness_angle,
+        left_gap_angle,
+    ):
+        cr.set_line_width(progress_thickness)
+        Gdk.cairo_set_source_rgba(cr, progress_color)
+
+        if progress_angle - progress_line_width_angle - left_gap_angle > start_angle:
+            # draw normal arc
+            arc_start = (
+                start_angle + (progress_line_width_angle - slider_thickness_angle) / 2
+            )
+            arc_end = (
+                progress_angle
+                - (progress_line_width_angle / 2 + slider_thickness_angle / 2)
+                - left_gap_angle
+            )
+            cr.arc(center_x, center_y, safe_radius, arc_start, arc_end)
+            cr.stroke()
+        else:
+            # draw shrinking dot when available space is minimal
+            ratio = progress_line_width_angle / (
+                progress_line_width_angle + left_gap_angle
+            )
+            dot_arc = (
+                -(
+                    start_angle
+                    - slider_thickness_angle / 2
+                    - (progress_angle - slider_thickness_angle / 2)
+                )
+                / 2
+                * ratio
+            )
+            dot_radius = 2 * safe_radius * math.sin(dot_arc)
+
+            cr.set_line_width(dot_radius)
+            true_start = start_angle - slider_thickness_angle / 2 + dot_arc
+            delta = self.do_get_arc_delta()
+            cr.arc(center_x, center_y, safe_radius, true_start, true_start + delta)
+            cr.stroke()
+            cr.set_line_width(safe_radius * progress_line_width_angle)
+
+    def do_draw_slider(
+        self,
+        cr,
+        center_x,
+        center_y,
+        safe_radius,
+        progress_angle,
+        slider_color,
+        slider_thickness_angle,
+        slider_height,
+        corner_radius,
+    ):
+        angle_rad = progress_angle
+        sx = center_x + math.cos(angle_rad) * safe_radius
+        sy = center_y + math.sin(angle_rad) * safe_radius
+
+        cr.save()
+        cr.translate(sx, sy)
+        cr.rotate(angle_rad + math.pi / 2)
+
+        Gdk.cairo_set_source_rgba(cr, slider_color)
+
+        self.do_draw_rounded_rect(
+            cr,
+            -(slider_thickness_angle * safe_radius) / 2,
+            -slider_height / 2,
+            slider_thickness_angle * safe_radius,
+            slider_height,
+            corner_radius,
+        )
+        cr.fill()
+        cr.restore()
+
+    def do_draw_trough_arc(
+        self,
+        cr,
+        center_x,
+        center_y,
+        safe_radius,
+        progress_angle,
+        real_end_angle,
+        trough_color,
+        trough_thickness,
+        trough_line_width_angle,
+        slider_thickness_angle,
+        right_gap_angle,
+    ):
+        cr.set_line_width(trough_thickness)
+        Gdk.cairo_set_source_rgba(cr, trough_color)
+
+        remaining_start = (
+            progress_angle + trough_line_width_angle / 2 + slider_thickness_angle / 2
+        )
+        remaining_end = (
+            real_end_angle - slider_thickness_angle / 2 - trough_line_width_angle / 2
+        )
+
+        if remaining_start < remaining_end - right_gap_angle:
+            # draw arc
+            cr.arc(
+                center_x,
+                center_y,
+                safe_radius,
+                remaining_start + right_gap_angle,
+                remaining_end,
+            )
+            cr.stroke()
+        else:
+            # draw shrinking dot when remaining space is minimal
+            ratio = trough_line_width_angle / (
+                trough_line_width_angle + right_gap_angle
+            )
+            true_end = real_end_angle - slider_thickness_angle / 2
+            remaining_angle = true_end - (progress_angle + slider_thickness_angle / 2)
+            remaining_usable_angle = max(remaining_angle, 0.0) * ratio
+
+            chord_length = 2 * safe_radius * math.sin(remaining_usable_angle / 2)
+            cr.set_line_width(chord_length)
+
+            mid_angle = (
+                progress_angle
+                + slider_thickness_angle / 2
+                + remaining_angle * (1 - ratio)
+                + remaining_usable_angle / 2
+            )
+            delta = self.do_get_arc_delta()
+            cr.arc(center_x, center_y, safe_radius, mid_angle, mid_angle + delta)
+            cr.stroke()
+
+    def do_draw(self, cr: cairo.Context):
+        state = self.get_state_flags()
+        style_context = self.get_style_context()
+
+        border = style_context.get_border(state)
+        background_color = style_context.get_background_color(state)
+
+        width = self.get_allocated_width()
+        height = self.get_allocated_height()
+        center_x = width / 2
+        center_y = height / 2
+
+        # slider properties
+        slider_color = self.slider_ctx.get_background_color(state)
+        slider_height = self.slider_ctx.get_property("min-height", state)
+        slider_thickness = self.slider_ctx.get_property("min-width", state)
+        left_gap = self.slider_ctx.get_property("margin-left", state)
+        right_gap = self.slider_ctx.get_property("margin-right", state)
+        corner_radius = self.slider_ctx.get_property("border-radius", state)
+
+        # progress (highlight) properties
+        progress_color = self.highlight_ctx.get_background_color(state)
+        progress_thickness = self.do_get_thickness_from_context(self.highlight_ctx, state)
+
+        # trough properties
+        trough_color = self.trough_ctx.get_background_color(state)
+        trough_thickness = self.do_get_thickness_from_context(self.trough_ctx, state)
+
+        # calculate radius
+        radius = self.do_calculate_radius()
+        safe_radius = self.do_calculate_safe_radius(
+            radius, slider_height, progress_thickness, trough_thickness
+        )
+        if safe_radius == 0:
+            if child := self.get_child():
+                self.propagate_draw(child, cr)
+            return
+
+        cr.save()
+        cr.set_line_cap(self._line_style)
+
+        # background fill
+        cr.set_line_width(0)
+        Gdk.cairo_set_source_rgba(cr, background_color)
+        cr.arc(center_x, center_y, radius, 0, 2 * math.pi)
+        cr.fill()
+
+        # angles (S = r*theta)
+        left_gap_angle = left_gap / safe_radius
+        right_gap_angle = right_gap / safe_radius
+        progress_line_width_angle = progress_thickness / safe_radius
+        trough_line_width_angle = trough_thickness / safe_radius
+        slider_thickness_angle = slider_thickness / safe_radius
+
+        start_angle = math.radians(self._start_angle)
+        end_angle = (
+            math.radians(self._end_angle) - slider_thickness_angle - right_gap_angle
+        )
+        real_end_angle = math.radians(self._end_angle) - right_gap_angle
+
+        normalized_value = self.do_normalize_value()
+        progress_angle = start_angle + normalized_value * (end_angle - start_angle)
+
+        # exposed for override
+        self.do_draw_progress_arc(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            safe_radius=safe_radius,
+            start_angle=start_angle,
+            progress_angle=progress_angle,
+            progress_color=progress_color,
+            progress_thickness=progress_thickness,
+            progress_line_width_angle=progress_line_width_angle,
+            slider_thickness_angle=slider_thickness_angle,
+            left_gap_angle=left_gap_angle,
+        )
+
+        self.do_draw_slider(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            safe_radius=safe_radius,
+            progress_angle=progress_angle,
+            slider_color=slider_color,
+            slider_thickness_angle=slider_thickness_angle,
+            slider_height=slider_height,
+            corner_radius=corner_radius,
+        )
+
+        self.do_draw_trough_arc(
+            cr=cr,
+            center_x=center_x,
+            center_y=center_y,
+            safe_radius=safe_radius,
+            progress_angle=progress_angle,
+            real_end_angle=real_end_angle,
+            trough_color=trough_color,
+            trough_thickness=trough_thickness,
+            trough_line_width_angle=trough_line_width_angle,
+            slider_thickness_angle=slider_thickness_angle,
+            right_gap_angle=right_gap_angle,
+        )
+
+        # draw child (if any)
+        if child := self.get_child():
+            self.propagate_draw(child, cr)
+
+        cr.restore()
+        return False
+
+    def do_create_gadget_context(self, node_name):
+        ctx = Gtk.StyleContext()
+        ctx.set_parent(self.get_style_context())
+
+        path = self.get_style_context().get_path().copy()
+        path.append_type(GObject.TYPE_NONE)
+        path.iter_set_object_name(-1, node_name)
+
+        ctx.connect("changed", lambda _: self.queue_draw())
+        ctx.set_path(path)
+        return ctx
+
+    def do_draw_rounded_rect(self, cr, x, y, width, height, radius):
+        if isinstance(radius, (int, float)):
+            rtl = rtr = rbr = rbl = float(radius)
+        else:
+            rtl, rtr, rbr, rbl = map(float, radius)
+
+        rtl, rtr, rbr, rbl = [max(0.0, v) for v in [rtl, rtr, rbr, rbl]]
+
+        # for scaling down overflowing corner radius
+        factor = 1.0
+
+        # top edge
+        if (rtl + rtr) > width:
+            factor = min(factor, width / (rtl + rtr))
+        # bottom edge
+        if (rbl + rbr) > width:
+            factor = min(factor, width / (rbl + rbr))
+        # left edge
+        if (rtl + rbl) > height:
+            factor = min(factor, height / (rtl + rbl))
+        # right edge
+        if (rtr + rbr) > height:
+            factor = min(factor, height / (rtr + rbr))
+
+        if factor < 1.0:
+            rtl *= factor
+            rtr *= factor
+            rbr *= factor
+            rbl *= factor
+
+        cr.new_sub_path()
+
+        if rtl == rtr == rbr == rbl == 0:
+            cr.rectangle(x, y, width, height)
+            return
+
+        # top-left (after the corner curve)
+        cr.move_to(x + rtl, y)
+
+        # top edge & top-right corner
+        cr.line_to(x + width - rtr, y)
+        if rtr > 0:
+            cr.arc(x + width - rtr, y + rtr, rtr, -math.pi / 2, 0)
+
+        # right edge & bottom-right corner
+        cr.line_to(x + width, y + height - rbr)
+        if rbr > 0:
+            cr.arc(x + width - rbr, y + height - rbr, rbr, 0, math.pi / 2)
+
+        # bottom edge & bottom-left corner
+        cr.line_to(x + rbl, y + height)
+        if rbl > 0:
+            cr.arc(x + rbl, y + height - rbl, rbl, math.pi / 2, math.pi)
+
+        # left edge & top-left corner
+        cr.line_to(x, y + rtl)
+        if rtl > 0:
+            cr.arc(x + rtl, y + rtl, rtl, math.pi, 3 * math.pi / 2)
+
+        cr.close_path()

--- a/fabric/widgets/circularscale.py
+++ b/fabric/widgets/circularscale.py
@@ -70,8 +70,8 @@ class CircularScale(CircularProgressBar):
             size,
             **kwargs,
         )
+        self._cached_style: dict = {}
         self._gadget_classes: dict[Gtk.StyleContext, frozenset[str] | None] = {}
-
         # gadgets
         self._highlight_ctx = self.do_create_gadget_context("highlight")
         self._trough_ctx = self.do_create_gadget_context("trough")
@@ -90,7 +90,6 @@ class CircularScale(CircularProgressBar):
 
     def do_update_gadget_path(self, context: Gtk.StyleContext, node_name: str) -> None:
         parent_ctx = self.get_style_context()
-        new_path = parent_ctx.get_path().copy()
         current_classes = frozenset(parent_ctx.list_classes())
 
         # GTK's WidgetPath only includes style classes if CSS rules target them.
@@ -101,16 +100,37 @@ class CircularScale(CircularProgressBar):
         # the parent's path so the selectors can match correctly.
         if current_classes != self._gadget_classes[context]:
             self._gadget_classes[context] = current_classes
-            for cls in current_classes:
-                if not new_path.iter_has_class(-1, cls):
-                    new_path.iter_add_class(-1, cls)
+            new_path = parent_ctx.get_path().copy()
+            new_path.append_for_widget(self)  # copies name + classes
             new_path.append_type(GObject.TYPE_NONE)
             new_path.iter_set_object_name(-1, node_name)
             context.set_path(new_path)
 
-        # TODO: add independent state support for each sub-node
+        # TODO: add independent state support for each sub-node. We don't have 
+        # any state based styles implemented.
         context.set_state(self.get_state_flags())
+        self._cached_style.clear()
         self.queue_draw()
+
+    def do_resolve_style(self) -> dict:
+        if self._cached_style:
+            return self._cached_style
+        
+        state = self.get_state_flags()
+        self._cached_style = {
+            "slider_color": self._slider_ctx.get_background_color(state),
+            "slider_height": self._slider_ctx.get_property("min-height", state),
+            "slider_thickness": self._slider_ctx.get_property("min-width", state),
+            "left_gap": self._slider_ctx.get_property("margin-left", state),
+            "right_gap": self._slider_ctx.get_property("margin-right", state),
+            "corner_radius": self._slider_ctx.get_property("border-radius", state),
+            "progress_color": self._highlight_ctx.get_background_color(state),
+            "progress_thickness": self.do_get_border_width(self._highlight_ctx, state),
+            "trough_color": self._trough_ctx.get_background_color(state),
+            "trough_thickness": self.do_get_border_width(self._trough_ctx, state),
+            "background_color": self.get_style_context().get_background_color(state),
+        }
+        return self._cached_style
 
     def do_get_border_width(
         self, context: Gtk.StyleContext, state: Gtk.StateFlags
@@ -338,10 +358,9 @@ class CircularScale(CircularProgressBar):
         cr.close_path()
 
     def do_draw(self, cr: cairo.Context) -> None:
-        state = self.get_state_flags()
-        style_context = self.get_style_context()
+        styles = self.do_resolve_style()
 
-        background_color = style_context.get_background_color(state)  # type: ignore
+        background_color = styles['background_color']  # type: ignore
 
         width = self.get_allocated_width()
         height = self.get_allocated_height()
@@ -349,20 +368,20 @@ class CircularScale(CircularProgressBar):
         center_y = height / 2
 
         # slider properties
-        slider_color = self._slider_ctx.get_background_color(state)  # type: ignore
-        slider_height = self._slider_ctx.get_property("min-height", state)  # type: ignore
-        slider_thickness = self._slider_ctx.get_property("min-width", state)  # type: ignore
-        left_gap = self._slider_ctx.get_property("margin-left", state)  # type: ignore
-        right_gap = self._slider_ctx.get_property("margin-right", state)  # type: ignore
-        corner_radius = self._slider_ctx.get_property("border-radius", state)  # type: ignore
+        slider_color = styles['slider_color']
+        slider_height = styles['slider_height']
+        slider_thickness = styles['slider_thickness']
+        left_gap = styles['left_gap']
+        right_gap = styles['right_gap']
+        corner_radius = styles['corner_radius']
 
         # progress (highlight) properties
-        progress_color = self._highlight_ctx.get_background_color(state)  # type: ignore
-        progress_thickness = self.do_get_border_width(self._highlight_ctx, state)
+        progress_color = styles['progress_color']
+        progress_thickness = styles["progress_thickness"]
 
         # trough properties
-        trough_color = self._trough_ctx.get_background_color(state)  # type: ignore
-        trough_thickness = self.do_get_border_width(self._trough_ctx, state)
+        trough_color = styles['trough_color']
+        trough_thickness = styles["trough_thickness"]
 
         # calculate radius
         radius = self.do_calculate_radius()

--- a/fabric/widgets/circularscale.py
+++ b/fabric/widgets/circularscale.py
@@ -70,6 +70,8 @@ class CircularScale(CircularProgressBar):
             size,
             **kwargs,
         )
+        self._gadget_classes: dict[Gtk.StyleContext, frozenset[str] | None] = {}
+
         # gadgets
         self._highlight_ctx = self.do_create_gadget_context("highlight")
         self._trough_ctx = self.do_create_gadget_context("trough")
@@ -79,33 +81,35 @@ class CircularScale(CircularProgressBar):
         ctx = Gtk.StyleContext()
         ctx.set_parent(self.get_style_context())
         ctx.set_screen(self.get_screen())
+        self._gadget_classes[ctx] = None
 
-        ctx.connect('changed', lambda *_: self.do_update_gadget_path(ctx, node_name))
-        
+        ctx.connect("changed", lambda *_: self.do_update_gadget_path(ctx, node_name))
+
         self.do_update_gadget_path(ctx, node_name)
         return ctx
-    
+
     def do_update_gadget_path(self, context: Gtk.StyleContext, node_name: str) -> None:
         parent_ctx = self.get_style_context()
         new_path = parent_ctx.get_path().copy()
-        
+        current_classes = frozenset(parent_ctx.list_classes())
+
         # GTK's WidgetPath only includes style classes if CSS rules target them.
         # If there are selectors targeting child nodes with parent classes
-        # (e.g., "circle-widget.dark slider {...}") but no rules directly targeting 
+        # (e.g., "circle-widget.dark slider {...}") but no rules directly targeting
         # the parent with that class (e.g., "circle-widget.dark {...}"), the parent's
         # path won't include the class. This solution manually adds these classes to
         # the parent's path so the selectors can match correctly.
-        for cls in parent_ctx.list_classes():
-            if not new_path.iter_has_class(-1, cls):
-                new_path.iter_add_class(-1, cls)
+        if current_classes != self._gadget_classes[context]:
+            self._gadget_classes[context] = current_classes
+            for cls in current_classes:
+                if not new_path.iter_has_class(-1, cls):
+                    new_path.iter_add_class(-1, cls)
+            new_path.append_type(GObject.TYPE_NONE)
+            new_path.iter_set_object_name(-1, node_name)
+            context.set_path(new_path)
 
-        new_path.append_type(GObject.TYPE_NONE)
-        new_path.iter_set_object_name(-1, node_name) 
-        
-        context.set_path(new_path)
         # TODO: add independent state support for each sub-node
         context.set_state(self.get_state_flags())
-
         self.queue_draw()
 
     def do_get_border_width(

--- a/fabric/widgets/circularscale.py
+++ b/fabric/widgets/circularscale.py
@@ -1,12 +1,26 @@
 import gi
 import math
 import cairo
-from typing import Iterable, Literal, Tuple
+from typing import Iterable, Literal, TypedDict
 from fabric.widgets.circularprogressbar import CircularProgressBar
 from fabric.utils.helpers import clamp
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk, GObject
+
+
+class CircularScaleStyle(TypedDict):
+    slider_color: Gdk.RGBA
+    slider_height: float
+    slider_thickness: float
+    left_gap: float
+    right_gap: float
+    corner_radius: float
+    progress_color: Gdk.RGBA
+    progress_thickness: float
+    trough_color: Gdk.RGBA
+    trough_thickness: float
+    background_color: Gdk.RGBA
 
 
 class CircularScale(CircularProgressBar):
@@ -70,7 +84,7 @@ class CircularScale(CircularProgressBar):
             size,
             **kwargs,
         )
-        self._cached_style: dict = {}
+        self._cached_style: CircularScaleStyle | None = None
         self._gadget_classes: dict[Gtk.StyleContext, frozenset[str] | None] = {}
         # gadgets
         self._highlight_ctx = self.do_create_gadget_context("highlight")
@@ -91,7 +105,6 @@ class CircularScale(CircularProgressBar):
     def do_update_gadget_path(self, context: Gtk.StyleContext, node_name: str) -> None:
         parent_ctx = self.get_style_context()
         current_classes = frozenset(parent_ctx.list_classes())
-
         # GTK's WidgetPath only includes style classes if CSS rules target them.
         # If there are selectors targeting child nodes with parent classes
         # (e.g., "circle-widget.dark slider {...}") but no rules directly targeting
@@ -101,40 +114,44 @@ class CircularScale(CircularProgressBar):
         if current_classes != self._gadget_classes[context]:
             self._gadget_classes[context] = current_classes
             new_path = parent_ctx.get_path().copy()
-            new_path.append_for_widget(self)  # copies name + classes
+            for cls in list(new_path.iter_list_classes(-1)):
+                if cls not in current_classes:
+                    new_path.iter_remove_class(-1, cls)
+            for cls in current_classes:
+                if not new_path.iter_has_class(-1, cls):
+                    new_path.iter_add_class(-1, cls)
             new_path.append_type(GObject.TYPE_NONE)
             new_path.iter_set_object_name(-1, node_name)
             context.set_path(new_path)
 
-        # TODO: add independent state support for each sub-node. We don't have 
-        # any state based styles implemented.
+        # TODO: add independent state support for each sub-node.
         context.set_state(self.get_state_flags())
-        self._cached_style.clear()
+        self._cached_style = None  # invalidate cache
         self.queue_draw()
 
     def do_resolve_style(self) -> dict:
-        if self._cached_style:
+        if self._cached_style is not None:
             return self._cached_style
-        
+
         state = self.get_state_flags()
-        self._cached_style = {
-            "slider_color": self._slider_ctx.get_background_color(state),
-            "slider_height": self._slider_ctx.get_property("min-height", state),
-            "slider_thickness": self._slider_ctx.get_property("min-width", state),
-            "left_gap": self._slider_ctx.get_property("margin-left", state),
-            "right_gap": self._slider_ctx.get_property("margin-right", state),
-            "corner_radius": self._slider_ctx.get_property("border-radius", state),
-            "progress_color": self._highlight_ctx.get_background_color(state),
-            "progress_thickness": self.do_get_border_width(self._highlight_ctx, state),
-            "trough_color": self._trough_ctx.get_background_color(state),
-            "trough_thickness": self.do_get_border_width(self._trough_ctx, state),
-            "background_color": self.get_style_context().get_background_color(state),
-        }
+        self._cached_style = CircularScaleStyle(
+            slider_color=self._slider_ctx.get_background_color(state),
+            slider_height=self._slider_ctx.get_property("min-height", state),
+            slider_thickness=self._slider_ctx.get_property("min-width", state),
+            left_gap=self._slider_ctx.get_property("margin-left", state),
+            right_gap=self._slider_ctx.get_property("margin-right", state),
+            corner_radius=self._slider_ctx.get_property("border-radius", state),
+            progress_color=self._highlight_ctx.get_background_color(state),
+            progress_thickness=self.do_get_border_width(self._highlight_ctx, state),
+            trough_color=self._trough_ctx.get_background_color(state),
+            trough_thickness=self.do_get_border_width(self._trough_ctx, state),
+            background_color=self.get_style_context().get_background_color(state),
+        )
         return self._cached_style
 
     def do_get_border_width(
         self, context: Gtk.StyleContext, state: Gtk.StateFlags
-    ) -> float:
+    ) -> int:
         border = context.get_border(state)  # type: ignore
         return max(
             self._line_width,
@@ -221,7 +238,7 @@ class CircularScale(CircularProgressBar):
         slider_color: Gdk.RGBA,
         slider_thickness_angle: float,
         slider_height: float,
-        corner_radius: float | Tuple[float, float, float, float],
+        corner_radius: float | tuple[float, float, float, float],
     ) -> None:
         angle_rad = progress_angle
         sx = center_x + math.cos(angle_rad) * radius
@@ -306,7 +323,7 @@ class CircularScale(CircularProgressBar):
         y: float,
         width: float,
         height: float,
-        radius: float | Tuple[float, float, float, float],
+        radius: float | tuple[float, float, float, float],
     ) -> None:
         if isinstance(radius, (int, float)):
             rtl = rtr = rbr = rbl = float(radius)
@@ -360,7 +377,7 @@ class CircularScale(CircularProgressBar):
     def do_draw(self, cr: cairo.Context) -> None:
         styles = self.do_resolve_style()
 
-        background_color = styles['background_color']  # type: ignore
+        background_color = styles["background_color"]
 
         width = self.get_allocated_width()
         height = self.get_allocated_height()
@@ -368,19 +385,19 @@ class CircularScale(CircularProgressBar):
         center_y = height / 2
 
         # slider properties
-        slider_color = styles['slider_color']
-        slider_height = styles['slider_height']
-        slider_thickness = styles['slider_thickness']
-        left_gap = styles['left_gap']
-        right_gap = styles['right_gap']
-        corner_radius = styles['corner_radius']
+        slider_color = styles["slider_color"]
+        slider_height = styles["slider_height"]
+        slider_thickness = styles["slider_thickness"]
+        left_gap = styles["left_gap"]
+        right_gap = styles["right_gap"]
+        corner_radius = styles["corner_radius"]
 
         # progress (highlight) properties
-        progress_color = styles['progress_color']
+        progress_color = styles["progress_color"]
         progress_thickness = styles["progress_thickness"]
 
         # trough properties
-        trough_color = styles['trough_color']
+        trough_color = styles["trough_color"]
         trough_thickness = styles["trough_thickness"]
 
         # calculate radius


### PR DESCRIPTION
This PR introduces a new widget, `CircularScale` which aims to behave as a circular analogue to `Scale`.

### Features
The Circular Scale has three gadgets (all the same level in hierarchy, unlike `Scale`):
```
CircularScale
├── trough
├── highlight
└── slider
```
<table>
  <thead>
    <tr>
      <th>Gadget</th>
      <th>Property</th>
      <th>Effect</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td rowspan="5"><b>slider</b></td>
      <td><code>min-width</code></td>
      <td>Slider thickness</td>
    </tr>
    <tr>
      <td><code>min-height</code></td>
      <td>Slider height</td>
    </tr>
    <tr>
      <td><code>margin-left</code></td>
      <td>Angular gap before the slider and before the start of the progress arc</td>
    </tr>
<tr>
      <td><code>margin-right</code></td>
      <td>Angular gap after the slider and after the end of the trough arc</td>
    </tr>
    <tr>
      <td><code>border-radius</code></td>
      <td>Rounded corners</td>
    </tr>
    <tr>
      <td rowspan="2"><b>highlight</b></td>
      <td><code>background-color</code></td>
      <td>Color of the progress arc</td>
    </tr>
    <tr>
      <td><code>min-width/height/border-width</code></td>
      <td>Thickness of the progress arc</td>
    </tr>
    <tr>
      <td rowspan="2"><b>trough</b></td>
      <td><code>background-color</code></td>
      <td>Color of the trough arc</td>
    </tr>
    <tr>
      <td><code>min-width/height/border-width</code></td>
      <td>Thickness of the trough arc</td>
    </tr>
    <tr>
      <td colspan="3"><b>Base styles</b></td>
    </tr>
<tr>
      <td colspan='2'><code>background-color</code></td>
      <td>Background color of the widget (circular)</td>
</tr>
  </tbody>
</table>

### Performance
The `CircularScale` is approximately 5.8x faster in draw cycles compared to `CircularProgressBar`. Its probably because of the gadgets usage.

### Suggestions
- **Add independant margin support to the progress and trought arc**</br>As of now, the arcs reflect the margins of the slider, which works fine, but adding it would make the widget more configurable.
- More styling (borders, gradients, background-image, etc).

https://github.com/user-attachments/assets/852344e7-4a35-4657-8ba8-15e26a98f3fa

