### PR TITLE
fix: CenterBox spacing

### DIFF
--- a/fabric/widgets/centerbox.py
+++ b/fabric/widgets/centerbox.py
@@ -80,7 +80,7 @@ class CenterBox(Box):
             Gtk.Orientation.HORIZONTAL: Gtk.Orientation.VERTICAL,
         }.get(orientation, Gtk.Orientation.VERTICAL)
         super().__init__(
-            spacing,
+            0,
             orientation_flipped,
             None,
             name,
@@ -106,6 +106,7 @@ class CenterBox(Box):
             )
 
         self._inner = box_factory()
+        self._inner.set_spacing(spacing)
 
         self.start_container = box_factory()
         self.center_container = box_factory()


### PR DESCRIPTION
Fix for #159, I also set the parent spacing argument to 0 to avoid confusion (since it only has one child, spacing does not make much sense)