### PR TITLE
fix: correctly handle urgency 0 notification hints

### DIFF
--- a/fabric/notifications/service.py
+++ b/fabric/notifications/service.py
@@ -323,7 +323,9 @@ class Notification(Service):
         self._hints: GLib.Variant = raw_variant.get_child_value(6)  # type: ignore
         self._timeout: int = raw_variant.get_child_value(7).unpack()  # type: ignore
 
-        self._urgency: int = self.do_get_hint_entry("urgency") or 1  # type: ignore
+        self._urgency: int = (
+            0 if ((v := self.do_get_hint_entry("urgency")) is None) else v
+        )  # type: ignore
 
         self._image_file: str | None = self.do_get_hint_entry(
             "image-path"
@@ -340,7 +342,7 @@ class Notification(Service):
         self, entry_key: str, unpack: bool = True
     ) -> GLib.Variant | Any | None:
         variant = self._hints.lookup_value(entry_key)
-        if not unpack or not variant:
+        if not unpack or variant is None:
             return variant
         return variant.unpack()  # type: ignore
 


### PR DESCRIPTION
`do_get_hint_entry()` used `not variant`, which caused urgency byte `0x00` to be treated as falsy and return a raw `GLib.Variant` instead of an int after `variant.unpack()`.

This PR fixes it by explicitly checking `variant is None`.