### PR TITLE
fix: optimize styles handle

### DIFF
--- a/fabric/widgets/widget.py
+++ b/fabric/widgets/widget.py
@@ -217,17 +217,18 @@ class Widget(Gtk.Widget, Service):
         )
         style = compile_css(style) if compile is True else style
 
-        self.get_style_context().remove_provider(
-            self._style_provider
-        ) if self._style_provider is not None and append is False else None
-
-        if self._style_provider is None:
+        style_context = self.get_style_context()
+        if not self._style_provider:
             self._style_provider = Gtk.CssProvider()
+
+        style_context.remove_provider(self._style_provider)
+
+        if append:
+            style = style + "\n" + self._style_provider.to_string()
+
         self._style_provider.load_from_data(style.encode())  # type: ignore
-        self.get_style_context().add_provider(
-            self._style_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER
-        )
-        return
+
+        return style_context.add_provider(self._style_provider, 800)
 
     @overload
     def set_cursor(

--- a/fabric/widgets/widget.py
+++ b/fabric/widgets/widget.py
@@ -154,6 +154,7 @@ class Widget(Gtk.Widget, Service):
         Service.__init__(self, **kwargs)
 
         self._style_provider: Gtk.CssProvider | None = None
+        self._style_compiled: str | None = None
         self._cursor: Gdk.Cursor | None = None
 
         self.set_name(name) if name is not None else None
@@ -217,11 +218,16 @@ class Widget(Gtk.Widget, Service):
         )
         style = compile_css(style) if compile is True else style
 
+        if style == self._style_compiled and self._style_provider is not None:
+            return
+
         self.get_style_context().remove_provider(
             self._style_provider
         ) if self._style_provider is not None and append is False else None
 
-        self._style_provider = Gtk.CssProvider()
+        if self._style_provider is None:
+            self._style_provider = Gtk.CssProvider()
+        self._style_compiled = style
         self._style_provider.load_from_data(style.encode())  # type: ignore
         self.get_style_context().add_provider(
             self._style_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER

--- a/fabric/widgets/widget.py
+++ b/fabric/widgets/widget.py
@@ -217,9 +217,6 @@ class Widget(Gtk.Widget, Service):
         )
         style = compile_css(style) if compile is True else style
 
-        if self._style_provider is not None:
-            return
-
         self.get_style_context().remove_provider(
             self._style_provider
         ) if self._style_provider is not None and append is False else None

--- a/fabric/widgets/widget.py
+++ b/fabric/widgets/widget.py
@@ -154,7 +154,6 @@ class Widget(Gtk.Widget, Service):
         Service.__init__(self, **kwargs)
 
         self._style_provider: Gtk.CssProvider | None = None
-        self._style_compiled: str | None = None
         self._cursor: Gdk.Cursor | None = None
 
         self.set_name(name) if name is not None else None
@@ -218,7 +217,7 @@ class Widget(Gtk.Widget, Service):
         )
         style = compile_css(style) if compile is True else style
 
-        if style == self._style_compiled and self._style_provider is not None:
+        if self._style_provider is not None:
             return
 
         self.get_style_context().remove_provider(
@@ -227,7 +226,6 @@ class Widget(Gtk.Widget, Service):
 
         if self._style_provider is None:
             self._style_provider = Gtk.CssProvider()
-        self._style_compiled = style
         self._style_provider.load_from_data(style.encode())  # type: ignore
         self.get_style_context().add_provider(
             self._style_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER


### PR DESCRIPTION
reuses the existing style provider - only allocates it on first call
caches the css and compiles only on change instead of subsequent calls