### PR TITLE
fix: return the correct polling state in the start method

### DIFF
--- a/fabric/core/fabricator.py
+++ b/fabric/core/fabricator.py
@@ -159,7 +159,7 @@ class Fabricator(Service, Generic[T]):
         process.wait_async(
             None, lambda *_: self.emit("polling-done", data)
         ) if process and self._stream else None
-        return True
+        return self._poll
 
     def do_invoke_function(self):
         if self._poll is not True:


### PR DESCRIPTION
This method is called via `GLib.timeout_add` which uses the return value to decide whether to keep firing. Even when `self._poll` is `False` and `result_handler` exits early, the function body still returns `True`, keeping the GLib timeout source alive forever. Should return `self._poll`.