### PR TITLE
perf: ensure socket lookup only occurs when necessary

### DIFF
--- a/fabric/hyprland/service.py
+++ b/fabric/hyprland/service.py
@@ -161,7 +161,9 @@ class Hyprland(Service):
         """
         resp = b""
         try:
-            _, socket_addr, *__ = Hyprland.lookup_socket()
+            if not Hyprland.COMMANDS_SOCKET:
+                Hyprland.lookup_socket()
+            socket_addr = Hyprland.COMMANDS_SOCKET
 
             # from Gio's docs:
             # > GSocketClient is a lightweight object, you don't need to cache it.
@@ -206,7 +208,9 @@ class Hyprland(Service):
         :param callback: the callback on where would you like to receive the reply of the command
         :type callback: Callable[[HyprlandReply], Any]
         """
-        _, socket_addr, *_ = Hyprland.lookup_socket()
+        if not Hyprland.COMMANDS_SOCKET:
+            Hyprland.lookup_socket()
+        socket_addr = Hyprland.COMMANDS_SOCKET
 
         # from Gio's docs:
         # > GSocketClient is a lightweight object, you don't need to cache it.

--- a/fabric/i3/service.py
+++ b/fabric/i3/service.py
@@ -166,8 +166,12 @@ class I3(Service):
         reply_data = {}
         is_ok = False
         try:
+            if not I3.SOCKET_PATH:
+                I3.lookup_socket()
+            socket_addr = I3.SOCKET_PATH
+
             with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-                sock.connect(I3.lookup_socket())
+                sock.connect(socket_addr)
                 sock.sendall(I3.pack(message_type, command))
 
                 _, payload = I3.unpack(sock)


### PR DESCRIPTION

In both hyprland and i3 service, the socket lookup was done in every command which costs some time even though the lookup already caches the socket.
Instead of lookup, this reuses that socket and only looks up when its null 