### PR TITLE
fix: initialize base Workspaces class in HyprlandWorkspaces

### DIFF
--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -29,6 +29,7 @@ class HyprlandWorkspaces(Workspaces):
         empty_scroll: bool = False,
         **kwargs,
     ):
+        super().__init__(buttons, buttons_factory, invert_scroll, **kwargs)
         """
         :param buttons: a list of predefined buttons, if a workspace was opened but no button representing it in the given list was found, call the buttons factory function to create a button for that workspace, defaults to None
         :type buttons: Iterable[WorkspaceButton] | None, optional

--- a/fabric/hyprland/widgets.py
+++ b/fabric/hyprland/widgets.py
@@ -29,7 +29,6 @@ class HyprlandWorkspaces(Workspaces):
         empty_scroll: bool = False,
         **kwargs,
     ):
-        super().__init__(buttons, buttons_factory, invert_scroll, **kwargs)
         """
         :param buttons: a list of predefined buttons, if a workspace was opened but no button representing it in the given list was found, call the buttons factory function to create a button for that workspace, defaults to None
         :type buttons: Iterable[WorkspaceButton] | None, optional
@@ -40,6 +39,8 @@ class HyprlandWorkspaces(Workspaces):
         :param empty_scroll: scroll through empty workspaces (if found in the list), defaults to False
         :type empty_scroll: bool, optional
         """
+        super().__init__(buttons, buttons_factory, invert_scroll, **kwargs)
+
         self.connection = get_hyprland_connection()
 
         self._focus_command_template = (


### PR DESCRIPTION
Fix `HyprlandWorkspaces` crashes with an `AttributeError` by adding the missing `super().__init__(...)` call so the base class is properly initialized.